### PR TITLE
✨ Feat: Posting관련 Entity 구현

### DIFF
--- a/src/main/java/com/hanghae/instagram/common/response/DataResponse.java
+++ b/src/main/java/com/hanghae/instagram/common/response/DataResponse.java
@@ -4,14 +4,10 @@ import lombok.Builder;
 import lombok.Getter;
 import org.springframework.http.ResponseEntity;
 
-import java.time.LocalDateTime;
-
 @Getter
 @Builder
 public class DataResponse<T> {
-    private final LocalDateTime timestamp = LocalDateTime.now();
     private final int status;
-    private final String code;
     private final String message;
     private T data;
 
@@ -20,7 +16,6 @@ public class DataResponse<T> {
                 .status(successCode.getHttpStatus())
                 .body(DataResponse.<T>builder()
                         .status(successCode.getHttpStatus().value())
-                        .code(successCode.name())
                         .message(successCode.getMessage())
                         .data(data)
                         .build()

--- a/src/main/java/com/hanghae/instagram/common/response/SuccessResponse.java
+++ b/src/main/java/com/hanghae/instagram/common/response/SuccessResponse.java
@@ -4,14 +4,10 @@ import lombok.Builder;
 import lombok.Getter;
 import org.springframework.http.ResponseEntity;
 
-import java.time.LocalDateTime;
-
 @Getter
 @Builder
 public class SuccessResponse {
-    private final LocalDateTime timestamp = LocalDateTime.now();
     private final int status;
-    private final String code;
     private final String message;
 
     public static ResponseEntity<SuccessResponse> toResponseEntity(SuccessCode successCode) {
@@ -19,7 +15,6 @@ public class SuccessResponse {
                 .status(successCode.getHttpStatus())
                 .body(SuccessResponse.builder()
                         .status(successCode.getHttpStatus().value())
-                        .code(successCode.name())
                         .message(successCode.getMessage())
                         .build()
                 );

--- a/src/main/java/com/hanghae/instagram/posting/entity/ImgMemberTag.java
+++ b/src/main/java/com/hanghae/instagram/posting/entity/ImgMemberTag.java
@@ -1,0 +1,29 @@
+package com.hanghae.instagram.posting.entity;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Getter
+@Entity
+@NoArgsConstructor
+public class ImgMemberTag {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private long id;
+
+    @Column(nullable = false)
+    private String memberNickname;
+
+    @Column(nullable = false)
+    private long coordinateX;
+
+    @Column(nullable = false)
+    private long coordinateY;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "POSTING_IMG_ID")
+    private PostingImg postingImg;
+
+}

--- a/src/main/java/com/hanghae/instagram/posting/entity/Posting.java
+++ b/src/main/java/com/hanghae/instagram/posting/entity/Posting.java
@@ -3,17 +3,21 @@ package com.hanghae.instagram.posting.entity;
 import com.hanghae.instagram.comment.entity.Comment;
 import com.hanghae.instagram.common.entity.Timestamped;
 import com.hanghae.instagram.member.entity.Member;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
 import java.util.ArrayList;
 import java.util.List;
 
+@Getter
 @Entity
+@NoArgsConstructor
 public class Posting extends Timestamped {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+    private long id;
 
     @Column(nullable = false)
     private String contents;
@@ -26,6 +30,14 @@ public class Posting extends Timestamped {
     private Member member;
 
     @OneToMany(mappedBy = "posting", fetch = FetchType.LAZY)
-    private List<Comment> commentList = new ArrayList<>();
+    private List<PostingHashTag> postingHashTagList = new ArrayList<>();
 
+    @OneToMany(mappedBy = "posting", fetch = FetchType.LAZY)
+    private List<PostingMemberTag> postingMemberTagList = new ArrayList<>();
+
+    @OneToMany(mappedBy = "posting", fetch = FetchType.LAZY)
+    private List<PostingImg> postingImgList = new ArrayList<>();
+
+    @OneToMany(mappedBy = "posting", fetch = FetchType.LAZY)
+    private List<Comment> commentList = new ArrayList<>();
 }

--- a/src/main/java/com/hanghae/instagram/posting/entity/PostingHashTag.java
+++ b/src/main/java/com/hanghae/instagram/posting/entity/PostingHashTag.java
@@ -1,0 +1,22 @@
+package com.hanghae.instagram.posting.entity;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Getter
+@Entity
+@NoArgsConstructor
+public class PostingHashTag {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private long id;
+
+    @Column(nullable = false)
+    private String memberNickname;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "POSTING_ID", nullable = false)
+    private Posting posting;
+}

--- a/src/main/java/com/hanghae/instagram/posting/entity/PostingImg.java
+++ b/src/main/java/com/hanghae/instagram/posting/entity/PostingImg.java
@@ -1,0 +1,30 @@
+package com.hanghae.instagram.posting.entity;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@Entity
+@NoArgsConstructor
+public class PostingImg {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private long id;
+
+    @Column(nullable = false)
+    private String postingImg;
+
+    @Column(nullable = false)
+    private String postingImgNum;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "POSTING_ID", nullable = false)
+    private Posting posting;
+
+    @OneToMany(mappedBy = "postingImg", fetch = FetchType.LAZY)
+    private List<ImgMemberTag> imgMemberTagList = new ArrayList<>();
+}

--- a/src/main/java/com/hanghae/instagram/posting/entity/PostingMemberTag.java
+++ b/src/main/java/com/hanghae/instagram/posting/entity/PostingMemberTag.java
@@ -1,0 +1,22 @@
+package com.hanghae.instagram.posting.entity;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Getter
+@Entity
+@NoArgsConstructor
+public class PostingMemberTag {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private long id;
+
+    @Column(nullable = false)
+    private String memberNickname;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "POSTING_ID", nullable = false)
+    private Posting posting;
+}


### PR DESCRIPTION
Posting 관련 Entity 구현입니다. 내용이 많아 PR에 정리하겠습니다.

## PR 체크사항
PR이 다음 사항을 만족하는지 확인해주세요.

<!-- 
체크하려면 괄호 안에 "x"를 입력하세요. 
각 규칙은 Convention 문서에 있습니다.
PR 제목에 쓰는 prefix는 다음과 같습니다.
🚀 Release
🐛 Fix
✨ Feat
📝 Doc
♻️ Refactor
🔧 Chore
⏪️ Revert
🧪 Test
🎉 Init
-->

- [x] 커밋 제목 규칙
- [x] 커밋 메시지 작성 가이드라인
- [x] 라벨, 담당자, 리뷰어 지정


## PR 타입
어떤 유형의 PR인지 체크해주세요.

<!-- 체크하려면 괄호 안에 "x"를 입력하세요. -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:


## PR 설명
### 1. ERD 구조
![instagram (1)](https://user-images.githubusercontent.com/72681875/209425194-1dbbee7a-252b-4b34-b219-cea61b44f5eb.png)
### 2. 비정규화 문제
> https://velog.io/@bsjp400/Database-DB-%EC%A0%95%EA%B7%9C%ED%99%94-%EB%B9%84%EC%A0%95%EA%B7%9C%ED%99%94%EB%9E%80

현재 ERD 구조 보시면, 회원 정보가 필요한 부분을 다 회원 Nickname으로 대체하고 관계를 없애놓은 상태입니다. 이렇게 구성한 이유는 크게 네 가지 입니다.
1. 각 객체에서 회원에 대한 추가적인 정보(이메일, 비밀번호 등)이 필요할 일이 없다.
2. 회원과 연관관계를 설정했을 때, 회원 테이블에서 회원 닉네임을 찾기 위해 추가적으로 쿼리를 날려야한다.
3. 실제로 각 객체에서 사용하는 Nickname을 컬럼에 넣어두면, 쿼리를 날려야하는 경우의 수를 줄일 수 있다.
4. 만일 회원에 대한 추가적인 정보가 필요하더라도, unique한 닉네임을 통해 어떻게든 찾을 수 있다.

이에 따른 단점으로는 다음과 같은 점들이 예상됩니다.
1. 정규화가 가지는 모든 장점들을 구현할 수 없음
2. 유저가 탈퇴하는 경우, 혹은 Nickname을 변경하는 경우 모든 테이블을 일일이 찾아다니면서 삭제 혹은 수정해야함.

일부러 극단적으로 한 상태입니다. 매니저님에게 뚜드려 맞기 위해..
의견이 엄청 다양할 것 같은데 의견 있으신 분들 남겨주시면 감사하겠습니다!

## 작업사항
- Entity 생성
![Diagram](https://user-images.githubusercontent.com/72681875/209427200-bf4e9fc5-c598-4292-9574-72a156204513.PNG)


## 변경로직
- 내용을 적어주세요.
