### PR TITLE
✨ Feat: PropertyValueException 핸들러 추가

### DIFF
--- a/src/main/java/com/hanghae/instagram/common/exception/ErrorExceptionHandler.java
+++ b/src/main/java/com/hanghae/instagram/common/exception/ErrorExceptionHandler.java
@@ -1,6 +1,8 @@
 package com.hanghae.instagram.common.exception;
 
 import lombok.extern.slf4j.Slf4j;
+import org.hibernate.PropertyValueException;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -12,12 +14,23 @@ import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExcep
 // 1-2. assignableTypes: ExceptionHandler가 적용되는 범위를 지정, 조건을 과하게 걸면 성능에 매우 안좋은 영향을 끼칠 수 있다.
 @RestControllerAdvice
 // 2. ResponseEntityExceptionHandler를 extend한 CustomExceptionHandler 선언
-public class CustomExceptionHandler extends ResponseEntityExceptionHandler {
+public class ErrorExceptionHandler extends ResponseEntityExceptionHandler {
     // 3. ExceptionHandler가 적용될 Exception의 종류를 명시(CustomException)
     @ExceptionHandler(value = { CustomException.class })
             // 4. ResponseEntity 형식으로 ErrorResponse를 변환하여 반환.
-            public ResponseEntity<ErrorResponse> handleCustomException(CustomException e) {
+    public ResponseEntity<ErrorResponse> handleCustomException(CustomException e) {
         log.error("handleCustomException throw CustomException : {}", e.getErrorCode());
         return ErrorResponse.toResponseEntity(e.getErrorCode());
+    }
+
+    @ExceptionHandler(PropertyValueException.class)
+    public ResponseEntity<ErrorResponse> handlerRequestNullValueException(PropertyValueException e){
+
+        String staticMessage = " 값이 null로 들어와 데이터를 저장 혹은 수정 할 수 없습니다.";
+        String message = e.getPropertyName() + staticMessage;
+
+        return ErrorResponse.toResponseEntity(HttpStatus.BAD_REQUEST, message);
+
+
     }
 }

--- a/src/main/java/com/hanghae/instagram/common/exception/ErrorResponse.java
+++ b/src/main/java/com/hanghae/instagram/common/exception/ErrorResponse.java
@@ -2,18 +2,14 @@ package com.hanghae.instagram.common.exception;
 
 import lombok.Builder;
 import lombok.Getter;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-
-import java.time.LocalDateTime;
 
 @Getter
 // 1. ErrorResponse를 Builder Pattern을 이용해 ResponseEntity로 변환하기 위해 선언
 @Builder
 public class ErrorResponse {
-    private final LocalDateTime timestamp = LocalDateTime.now();
     private final int status;
-    private final String error;
-    private final String code;
     private final String message;
 
     // 2. ErrorResponse를 Response Entity로 변환하는 Method
@@ -22,10 +18,19 @@ public class ErrorResponse {
                 .status(errorCode.getHttpStatus())
                 .body(ErrorResponse.builder()
                         .status(errorCode.getHttpStatus().value())
-                        .error(errorCode.getHttpStatus().name())
-                        .code(errorCode.name())
                         .message(errorCode.getMessage())
                         .build()
                 );
     }
+
+    public static ResponseEntity<ErrorResponse> toResponseEntity(HttpStatus status, String message ) {
+        return ResponseEntity
+                .status(status)
+                .body(ErrorResponse.builder()
+                        .status(status.value())
+                        .message(message)
+                        .build()
+                );
+    }
+
 }


### PR DESCRIPTION
## PR 체크사항
PR이 다음 사항을 만족하는지 확인해주세요.

<!-- 
체크하려면 괄호 안에 "x"를 입력하세요. 
각 규칙은 Convention 문서에 있습니다.
PR 제목에 쓰는 prefix는 다음과 같습니다.
🚀 Release
🐛 Fix
✨ Feat
📝 Doc
♻️ Refactor
🔧 Chore
⏪️ Revert
🧪 Test
🎉 Init
-->

- [x] 커밋 제목 규칙
- [x] 커밋 메시지 작성 가이드라인
- [x] 라벨, 담당자, 리뷰어 지정


## PR 타입
어떤 유형의 PR인지 체크해주세요.

<!-- 체크하려면 괄호 안에 "x"를 입력하세요. -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:


## PR 설명
PropertyValueException 발생 원인: Entity 설정에서 nullable을 false로 해둔 필드에 null값을 넣고 저장하려 하여 발생
→ 지난 프로젝트에서 개발 도중 Dto 특정 필드가 null로 들어와 500이 자주 터졌습니다. 500이 터진 이유는 프론트에서 모르기에 백에서 로그를 항상 확인했었습니다. 
이에 불편함을 느껴, 프론트에서 null로 보내줄 경우, 백에서 로그를 확인하는 것이 아닌 프론트에 에러 핸들링을 통해 무엇이 문제인지 알려주어 모두가 편리하게 개발할 수 있도록 하고자 합니다.

첫 시도: PropertyValueException을 Custom Exception으로 만들고자 하였습니다.
PropertyValueException은 이름만으로는 저희에게 생소해 어떠한 에러인지 모릅니다.  그래서 이름을 직관적으로 사용하고자  RequestNullValueException이라는 이름의 커스텀 Exception을 만들고자 하였었습니다.
<br/>

<img width="832" alt="스크린샷 2022-12-25 오후 4 07 17" src="https://user-images.githubusercontent.com/85235063/209459895-909de597-4a73-491d-8884-61326552aa09.png">
위의 사진의 fillInstackTrace()에 대해서는 아래 사진으로 내용을 첨부합니다.
<img width="1148" alt="스크린샷 2022-12-25 오후 4 19 27" src="https://user-images.githubusercontent.com/85235063/209459939-ea7a13d3-d11d-4085-b98d-7c6710f0e1a8.png">

문제는, ErrorExceptionHandler에서 아래와 같이 에러 핸들러를 `RequestNullValueException`에 대해 걸었을 경우, 에러가 잡히지 않았습니다.
<img width="832" alt="스크린샷 2022-12-25 오후 4 01 12" src="https://user-images.githubusercontent.com/85235063/209459990-eddde770-72c5-4df4-990a-25248f668ac0.png">
<br/>

그래서 기존의 에러 PropertyValueException에 대해 걸어 주었더니 에러가 잡혔습니다.
<img width="797" alt="스크린샷 2022-12-25 오후 4 20 36" src="https://user-images.githubusercontent.com/85235063/209459969-82c61e15-12c9-4097-9b63-9090b734e493.png">

testController를 만들어 예외를 던져보았더니 handlerRequestNullValueException()를 통해 에러가 잡히고 핸들링 되기는 합니다.
<img width="904" alt="스크린샷 2022-12-25 오후 4 25 45" src="https://user-images.githubusercontent.com/85235063/209460091-f3de4d42-9f0d-4b54-b6a1-5d9f37d2881a.png">

이를 통해 확신한 점은, 현재 제가 만든 CustomException은 단지 이름 용도로만 사용된다는 것입니다. 물론 본래의 의도 또한 이름을 가시성 있도록 바꿔주기 위함이 맞았지만, 우선 아래의 글을 한번 읽어주세요.

<img width="1082" alt="스크린샷 2022-12-25 오후 4 29 53" src="https://user-images.githubusercontent.com/85235063/209460301-409b44a5-37cb-4d47-99e5-0d13f34e5ad6.png">

위의 글을 읽고 제가 처리하고자 하는 예외는 두 상황에 맞지 않는 다는 것을 깨달았습니다.
그래서 저는 기존에 발생하는 예외를 단지 핸들링 하기 위함이기 때문에 굳이 CustomException을 만들어 사용하지 않기로 하였습니다!

또한, 저희의 현재 구현된 CustomException은 클라이언트 코드에 대한 추가적인 정보 혹은 행동을 제공하고 싶은 경우가 아닌 클래스 명이 주는 장점때문에 사용하는 경우 입니다. 저희와 비슷한 경우에는 static final로 예외를 캐싱하여 사용하는 방법을 통해 구현하는 로직이 예외 발생 비용을 줄일 수 있어 효율적이라고 합니다! (현재 저희의 코드 또한 enum을 사용하기 때문에.. 아마도.. 비슷하지 않을까?합니다. 현재의 제 지식에서 확답은 못드리겠네욥...)

또한, 클라이언트 코드에 대한 추가적인 정보 혹은 행동을 제공하고 싶은 경우는 직접 다른 CustomException을 만들어 사용해야 할 것 같습니다 :)
 
위의 내용들은 아래의 글을 첨부하여 작성하였습니다! 꼭 읽어주세요! 
CustomException에 대해 찾아보면서 마주한 수많은 글 중 제가 궁금했던 부분들이 자세히 작성된 좋은 내용입니다! 

### https://ssoco.tistory.com/m/69

### 마지막으로, 저희 entity를 db에 저장하는 비지니스로직에는 PropertyValueException예외를 추가적으로 던져주세요! 

또한 위의 내용에 대한 의견들을 남겨주시면 감사하겠습니다 👏🏻 🫡

## 작업사항
- PropertyValueException 에러 핸들링 
