### PR TITLE
♻️ Refactor: 상태 코드 방식 변경

### DIFF
--- a/src/main/java/com/hanghae/instagram/common/exception/ErrorCode.java
+++ b/src/main/java/com/hanghae/instagram/common/exception/ErrorCode.java
@@ -7,31 +7,30 @@ import org.springframework.http.HttpStatus;
 import static org.springframework.http.HttpStatus.*;
 
 @Getter
-// 1. Field HttpStatus, message를 인자로 ErrorCode 객체를 만들기 위해 선언
 @AllArgsConstructor
-// 2. Custom Exception의 Field로 사용될 Enum 값 정의
 public enum ErrorCode {
-    // 200 : 잘못된 요청
-    INVALID_EMAIL(OK, "유효하지 않은 이메일입니다."),
-    INVALID_PASSWORD(OK, "유효하지 않은 비밀번호입니다."),
-    INCORRECT_PASSWORD(OK, "비밀번호가 일치하지 않습니다."),
-    REQUIRED_ALL(OK,"모든 항목이 필수값입니다."), // 에러코드 고민해봐야 겠음
+    // 400 : 잘못된 요청
+    INVALID_EMAIL(BAD_REQUEST, "유효하지 않은 이메일입니다.", OK),
+    INVALID_PASSWORD(BAD_REQUEST, "유효하지 않은 비밀번호입니다.", OK),
+    INCORRECT_PASSWORD(BAD_REQUEST, "비밀번호가 일치하지 않습니다.", OK),
+    REQUIRED_ALL(BAD_REQUEST,"모든 항목이 필수값입니다.", OK), // 에러코드 고민해봐야 겠음
 
     /* 401 UNAUTHORIZED : 인증되지 않은 사용자 */
-    JWT_NOT_FOUND(UNAUTHORIZED, "토큰이 존재하지 않습니다."),
-    INVALID_JWT(UNAUTHORIZED, "유효하지 않은 토큰입니다."),
-    INVALID_AUTH_TOKEN(UNAUTHORIZED, "권한 정보가 일치하지 않는 토큰입니다"),
-    UNAUTHORIZED_USER(UNAUTHORIZED, "작성자만 삭제/수정할 수 있습니다."),
+    JWT_NOT_FOUND(UNAUTHORIZED, "토큰이 존재하지 않습니다.", UNAUTHORIZED),
+    INVALID_JWT(UNAUTHORIZED, "유효하지 않은 토큰입니다.", UNAUTHORIZED),
+    INVALID_AUTH_TOKEN(UNAUTHORIZED, "권한 정보가 일치하지 않는 토큰입니다", UNAUTHORIZED),
+    UNAUTHORIZED_USER(UNAUTHORIZED, "작성자만 삭제/수정할 수 있습니다.", UNAUTHORIZED),
+    REFRESH_TOKEN_NOT_FOUND(UNAUTHORIZED, "로그아웃 된 사용자입니다", UNAUTHORIZED),
+
 
     /* 404 NOT_FOUND : Resource 를 찾을 수 없음 */
-    MEMBER_NOT_FOUND(NOT_FOUND, "해당 유저 정보를 찾을 수 없습니다"),
-    COMMENT_NOT_FOUND(NOT_FOUND, "해당 댓글을 찾을 수 없습니다"),
-    FORUM_NOT_FOUND(NOT_FOUND, "해당 게시글을 찾을 수 없습니다"),
-    REFRESH_TOKEN_NOT_FOUND(NOT_FOUND, "로그아웃 된 사용자입니다"),
+    MEMBER_NOT_FOUND(NOT_FOUND, "해당 유저 정보를 찾을 수 없습니다", NOT_FOUND),
+    COMMENT_NOT_FOUND(NOT_FOUND, "해당 댓글을 찾을 수 없습니다", NOT_FOUND),
+    FORUM_NOT_FOUND(NOT_FOUND, "해당 게시글을 찾을 수 없습니다", NOT_FOUND),
 
     /* 409 CONFLICT : Resource 의 현재 상태와 충돌. 보통 중복된 데이터 존재 */
-    DUPLICATE_EMAIL(CONFLICT, "중복된 이메일입니다."),
-    DUPLICATE_NICKNAME(CONFLICT, "중복된 닉네임입니다.");
+    DUPLICATE_EMAIL(CONFLICT, "중복된 이메일입니다.", OK),
+    DUPLICATE_NICKNAME(CONFLICT, "중복된 닉네임입니다.", OK);
 
 
 
@@ -42,6 +41,7 @@ public enum ErrorCode {
 
 
     // field
-    private final HttpStatus httpStatus;
+    private final HttpStatus bodyStatus;
     private final String message;
+    private final HttpStatus httpStatus;
 }

--- a/src/main/java/com/hanghae/instagram/common/exception/ErrorResponse.java
+++ b/src/main/java/com/hanghae/instagram/common/exception/ErrorResponse.java
@@ -17,7 +17,7 @@ public class ErrorResponse {
         return ResponseEntity
                 .status(errorCode.getHttpStatus())
                 .body(ErrorResponse.builder()
-                        .status(errorCode.getHttpStatus().value())
+                        .status(errorCode.getBodyStatus().value())
                         .message(errorCode.getMessage())
                         .build()
                 );


### PR DESCRIPTION
body로 보내지는 상태코드와 헤더 상태코드 설정 분리

## PR 체크사항
PR이 다음 사항을 만족하는지 확인해주세요.

<!-- 
체크하려면 괄호 안에 "x"를 입력하세요. 
각 규칙은 Convention 문서에 있습니다.
PR 제목에 쓰는 prefix는 다음과 같습니다.
🚀 Release
🐛 Fix
✨ Feat
📝 Doc
♻️ Refactor
🔧 Chore
⏪️ Revert
🧪 Test
🎉 Init
-->

- [x] 커밋 제목 규칙
- [x] 커밋 메시지 작성 가이드라인
- [x] 라벨, 담당자, 리뷰어 지정


## PR 타입
어떤 유형의 PR인지 체크해주세요.

<!-- 체크하려면 괄호 안에 "x"를 입력하세요. -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:


## PR 설명
기존에는 errorCode에 작성된 상태코드가 브라우저의 헤더에도 영향을 끼치는 상황이었습니다.
이는 API 설계시, 프론트 분들이 에러가 아닌 따로 처리해줘야 하는 상황(ex. 중복 이메일 확인 등)에서 브라우저 헤더의 상태코드가 에러일 경우 처리하기 번거롭다고 하셨습니다.

즉 브라우저 헤더의 상태코드와 바디에 실리는 상태코드 값을 다르게 처리할 수 있도록 변경하였습니다. 
ex) 이메일 중복, 닉네임 중복 등 브라우저 헤더에는 200을 body의 상태코드에는 400대

<img width="896" alt="스크린샷 2022-12-26 오후 4 15 12" src="https://user-images.githubusercontent.com/85235063/209517603-eed8b623-6ce7-49dd-b2e2-667d63fbf7e3.png">


## 작업사항
- errorCode Enum에 bodyStatus 필드를 추가하여 body 값으로 보내지는 상태코드와, 헤더 상태코드를 분리 시킴 


## 변경로직
- errorCode 작성시, bodyStatus와 httpStatus를 고민하여 작성해주세요!