### PR TITLE
✨ Feat: Posting Create, Show 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation group: 'org.json', name: 'json', version: '20220924'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.h2database:h2'
     annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/hanghae/instagram/InstagramApplication.java
+++ b/src/main/java/com/hanghae/instagram/InstagramApplication.java
@@ -1,15 +1,41 @@
 package com.hanghae.instagram;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.hanghae.instagram.member.dto.RequestSignupMemberDto;
+import com.hanghae.instagram.member.entity.Member;
+import com.hanghae.instagram.member.mapper.MemberMapper;
+import com.hanghae.instagram.member.repository.MemberRepository;
+import org.springframework.boot.ApplicationRunner;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+import javax.annotation.Resource;
+import java.io.InputStream;
+import java.util.List;
 
 @EnableJpaAuditing
 @SpringBootApplication
 public class InstagramApplication {
-
     public static void main(String[] args) {
         SpringApplication.run(InstagramApplication.class, args);
     }
-
+    @Resource
+    private MemberRepository memberRepository;
+    @Resource
+    private MemberMapper memberMapper;
+    @Bean
+    public ApplicationRunner applicationRunner() {
+        return args -> {
+            InputStream jsonMember = this.getClass().getClassLoader().getResourceAsStream("json/memberData.json");
+            List<RequestSignupMemberDto> requestSignupMemberDtoList = new ObjectMapper().readValue(jsonMember, new TypeReference<>() {
+            });
+            for (int i = 0; i < requestSignupMemberDtoList.size(); i++) {
+                Member member = memberMapper.toEntity(requestSignupMemberDtoList.get(i));
+                memberRepository.save(member);
+            }
+        };
+    }
 }

--- a/src/main/java/com/hanghae/instagram/common/response/SuccessCode.java
+++ b/src/main/java/com/hanghae/instagram/common/response/SuccessCode.java
@@ -11,7 +11,9 @@ import static org.springframework.http.HttpStatus.OK;
 public enum SuccessCode {
     // User
     SIGNUP_USER_SUCCESS(OK, "회원 가입 성공"),
-    LOGIN_USER_SUCCESS(OK, "유저 로그인 성공");
+    LOGIN_USER_SUCCESS(OK, "유저 로그인 성공"),
+    CREATE_POSTING_SUCCESS(OK, "포스팅 등록 성공"),
+    SHOW_POSTING_SUCCESS(OK, "전체 포스팅 조회 성공");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/hanghae/instagram/posting/controller/PostingController.java
+++ b/src/main/java/com/hanghae/instagram/posting/controller/PostingController.java
@@ -1,0 +1,37 @@
+package com.hanghae.instagram.posting.controller;
+
+import com.hanghae.instagram.common.response.DataResponse;
+import com.hanghae.instagram.common.response.SuccessResponse;
+import com.hanghae.instagram.posting.dto.createPosting.RequestCreatePostingDto;
+import com.hanghae.instagram.posting.dto.showPosting.ResponseShowPostingDto;
+import com.hanghae.instagram.posting.service.PostingService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+import static com.hanghae.instagram.common.response.SuccessCode.CREATE_POSTING_SUCCESS;
+import static com.hanghae.instagram.common.response.SuccessCode.SHOW_POSTING_SUCCESS;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/posting")
+public class PostingController {
+    private final PostingService postingService;
+
+    @PostMapping()
+    public ResponseEntity<?> createPosting(@RequestBody RequestCreatePostingDto requestCreatePostingDto) {
+        postingService.createPosting(requestCreatePostingDto.toCreatePostingDto(), "user1@test");
+        return SuccessResponse.toResponseEntity(CREATE_POSTING_SUCCESS);
+    }
+
+    @GetMapping()
+    public ResponseEntity<?> showPosting(Pageable pageable) {
+        List<ResponseShowPostingDto> data = postingService.showPosting(pageable);
+        return DataResponse.toResponseEntity(SHOW_POSTING_SUCCESS, data);
+    }
+
+
+}

--- a/src/main/java/com/hanghae/instagram/posting/dto/createPosting/CreatePostingDto.java
+++ b/src/main/java/com/hanghae/instagram/posting/dto/createPosting/CreatePostingDto.java
@@ -1,0 +1,23 @@
+package com.hanghae.instagram.posting.dto.createPosting;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+public class CreatePostingDto {
+    private String contents;
+    private List<CreatePostingImgDto> imgList = new ArrayList<>();
+    private List<String> hashtagList = new ArrayList<>();
+    private List<String> membertagList = new ArrayList<>();
+
+    @Builder
+    public CreatePostingDto(String contents, List<CreatePostingImgDto> imgList, List<String> hashtagList, List<String> membertagList) {
+        this.contents = contents;
+        this.imgList = imgList;
+        this.hashtagList = hashtagList;
+        this.membertagList = membertagList;
+    }
+}

--- a/src/main/java/com/hanghae/instagram/posting/dto/createPosting/CreatePostingImgDto.java
+++ b/src/main/java/com/hanghae/instagram/posting/dto/createPosting/CreatePostingImgDto.java
@@ -1,0 +1,20 @@
+package com.hanghae.instagram.posting.dto.createPosting;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.ArrayList;
+import java.util.List;
+@Getter
+public class CreatePostingImgDto {
+    private long postingImgNum;
+    private String postingImg;
+    private List<CreatePostingImgMemberTagDto> memberTagList = new ArrayList<>();
+
+    @Builder
+    public CreatePostingImgDto(long postingImgNum, String postingImg, List<CreatePostingImgMemberTagDto> memberTagList) {
+        this.postingImgNum = postingImgNum;
+        this.postingImg = postingImg;
+        this.memberTagList = memberTagList;
+    }
+}

--- a/src/main/java/com/hanghae/instagram/posting/dto/createPosting/CreatePostingImgMemberTagDto.java
+++ b/src/main/java/com/hanghae/instagram/posting/dto/createPosting/CreatePostingImgMemberTagDto.java
@@ -1,0 +1,18 @@
+package com.hanghae.instagram.posting.dto.createPosting;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class CreatePostingImgMemberTagDto {
+    private String nickname;
+    private long coordinateX;
+    private long coordinateY;
+
+    @Builder
+    public CreatePostingImgMemberTagDto(String nickname, long coordinateX, long coordinateY) {
+        this.nickname = nickname;
+        this.coordinateX = coordinateX;
+        this.coordinateY = coordinateY;
+    }
+}

--- a/src/main/java/com/hanghae/instagram/posting/dto/createPosting/RequestCreatePostingDto.java
+++ b/src/main/java/com/hanghae/instagram/posting/dto/createPosting/RequestCreatePostingDto.java
@@ -1,0 +1,35 @@
+package com.hanghae.instagram.posting.dto.createPosting;
+
+import lombok.Getter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+public class RequestCreatePostingDto {
+    private String contents;
+    private List<RequestCreatePostingImgDto> imgList = new ArrayList<>();
+    private List<String> hashtagList = new ArrayList<>();
+    private List<String> membertagList  = new ArrayList<>();;
+
+    public CreatePostingDto toCreatePostingDto() {
+        List<CreatePostingImgDto> tmpImgList = new ArrayList<>();
+        for (int i = 0; i < imgList.size(); i++) {
+            tmpImgList.add(imgList.get(i).toCreatePostingImgDto());
+        }
+        List<String> tmpHashtagList = new ArrayList<>();
+        for (int i = 0; i < hashtagList.size(); i++) {
+            tmpHashtagList.add(hashtagList.get(i));
+        }
+        List<String> tmpMembertagList = new ArrayList<>();
+        for (int i = 0; i < membertagList.size(); i++) {
+            tmpMembertagList.add(membertagList.get(i));
+        }
+        return CreatePostingDto.builder()
+                .contents(contents)
+                .imgList(tmpImgList)
+                .hashtagList(tmpHashtagList)
+                .membertagList(tmpMembertagList)
+                .build();
+    }
+}

--- a/src/main/java/com/hanghae/instagram/posting/dto/createPosting/RequestCreatePostingImgDto.java
+++ b/src/main/java/com/hanghae/instagram/posting/dto/createPosting/RequestCreatePostingImgDto.java
@@ -1,0 +1,25 @@
+package com.hanghae.instagram.posting.dto.createPosting;
+
+import lombok.Getter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+public class RequestCreatePostingImgDto {
+    private long postingImgNum;
+    private String postingImg;
+    private List<RequestCreatePostingImgMemberTagDto> memberTagList = new ArrayList<>();
+
+    public CreatePostingImgDto toCreatePostingImgDto(){
+        List<CreatePostingImgMemberTagDto> tmp = new ArrayList<>();
+        for (int i = 0; i < memberTagList.size(); i++) {
+            tmp.add(memberTagList.get(i).toCreatePostingMemberTagDto());
+        }
+        return CreatePostingImgDto.builder()
+                .postingImgNum(postingImgNum)
+                .postingImg(postingImg)
+                .memberTagList(tmp)
+                .build();
+    }
+}

--- a/src/main/java/com/hanghae/instagram/posting/dto/createPosting/RequestCreatePostingImgMemberTagDto.java
+++ b/src/main/java/com/hanghae/instagram/posting/dto/createPosting/RequestCreatePostingImgMemberTagDto.java
@@ -1,0 +1,18 @@
+package com.hanghae.instagram.posting.dto.createPosting;
+
+import lombok.Getter;
+
+@Getter
+public class RequestCreatePostingImgMemberTagDto {
+    private String nickname;
+    private long coordinateX;
+    private long coordinateY;
+
+    public CreatePostingImgMemberTagDto toCreatePostingMemberTagDto(){
+        return CreatePostingImgMemberTagDto.builder()
+                .nickname(nickname)
+                .coordinateX(coordinateX)
+                .coordinateY(coordinateY)
+                .build();
+    }
+}

--- a/src/main/java/com/hanghae/instagram/posting/dto/showPosting/ResponseShowPostingDto.java
+++ b/src/main/java/com/hanghae/instagram/posting/dto/showPosting/ResponseShowPostingDto.java
@@ -1,0 +1,36 @@
+package com.hanghae.instagram.posting.dto.showPosting;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class ResponseShowPostingDto {
+    private long id;
+    private String contents;
+    private long likeCount;
+    private String nickname;
+    private long commentCount;
+    private boolean postingLike;
+    private List<String> hashtagList;
+    private List<String> membertagList;
+    private String createdAt;
+    private String modifiedAt;
+    private List<ShowPostingImgDto> imgList;
+
+    @Builder
+    public ResponseShowPostingDto(long id, String contents, long likeCount, String nickname, long commentCount, boolean postingLike, List<String> hashtagList, List<String> membertagList, String createdAt, String modifiedAt, List<ShowPostingImgDto> imgList) {
+        this.id = id;
+        this.contents = contents;
+        this.likeCount = likeCount;
+        this.nickname = nickname;
+        this.commentCount = commentCount;
+        this.postingLike = postingLike;
+        this.hashtagList = hashtagList;
+        this.membertagList = membertagList;
+        this.createdAt = createdAt;
+        this.modifiedAt = modifiedAt;
+        this.imgList = imgList;
+    }
+}

--- a/src/main/java/com/hanghae/instagram/posting/dto/showPosting/ShowPostingDto.java
+++ b/src/main/java/com/hanghae/instagram/posting/dto/showPosting/ShowPostingDto.java
@@ -1,0 +1,39 @@
+package com.hanghae.instagram.posting.dto.showPosting;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class ShowPostingDto {
+    private long id;
+    private String contents;
+    private long likeCount;
+    private String nickname;
+    private long commentCount;
+    private boolean postingLike;
+    private List<String> hashtagList;
+    private List<String> membertagList;
+    private String createdAt;
+    private String modifiedAt;
+    private List<ShowPostingImgDto> imgList;
+
+    public ResponseShowPostingDto toResponse(){
+        // 빌더 패턴을 이용할 때, List에 대한 DeepCopy가 필요. 일단 바쁘니 리팩토링 때 적용
+        return ResponseShowPostingDto.builder()
+                .id(id)
+                .contents(contents)
+                .likeCount(likeCount)
+                .nickname(nickname)
+                .commentCount(commentCount)
+                .postingLike(postingLike)
+                .hashtagList(hashtagList)
+                .membertagList(membertagList)
+                .createdAt(createdAt)
+                .modifiedAt(modifiedAt)
+                .imgList(imgList)
+                .build();
+    }
+}

--- a/src/main/java/com/hanghae/instagram/posting/dto/showPosting/ShowPostingImgDto.java
+++ b/src/main/java/com/hanghae/instagram/posting/dto/showPosting/ShowPostingImgDto.java
@@ -1,0 +1,13 @@
+package com.hanghae.instagram.posting.dto.showPosting;
+
+import lombok.Builder;
+import lombok.Getter;
+import java.util.List;
+
+@Getter
+@Builder
+public class ShowPostingImgDto {
+    private long postingImgNum;
+    private String postingImg;
+    private List<ShowPostingImgMemberTagDto> memberTagList;
+}

--- a/src/main/java/com/hanghae/instagram/posting/dto/showPosting/ShowPostingImgMemberTagDto.java
+++ b/src/main/java/com/hanghae/instagram/posting/dto/showPosting/ShowPostingImgMemberTagDto.java
@@ -1,0 +1,12 @@
+package com.hanghae.instagram.posting.dto.showPosting;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ShowPostingImgMemberTagDto {
+    private String nickname;
+    private long coordinateX;
+    private long coordinateY;
+}

--- a/src/main/java/com/hanghae/instagram/posting/entity/Posting.java
+++ b/src/main/java/com/hanghae/instagram/posting/entity/Posting.java
@@ -1,14 +1,12 @@
 package com.hanghae.instagram.posting.entity;
 
-import com.hanghae.instagram.comment.entity.Comment;
 import com.hanghae.instagram.common.entity.Timestamped;
 import com.hanghae.instagram.member.entity.Member;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
-import java.util.ArrayList;
-import java.util.List;
 
 @Getter
 @Entity
@@ -23,21 +21,27 @@ public class Posting extends Timestamped {
     private String contents;
     
     @Column(nullable = false)
-    private int likeCount;
+    private int likeCount = 0;
     
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "MEMBER_ID")
     private Member member;
 
-    @OneToMany(mappedBy = "posting", fetch = FetchType.LAZY)
-    private List<PostingHashTag> postingHashTagList = new ArrayList<>();
+//    @OneToMany(mappedBy = "posting", fetch = FetchType.LAZY)
+//    private List<PostingHashTag> postingHashTagList = new ArrayList<>();
+//
+//    @OneToMany(mappedBy = "posting", fetch = FetchType.LAZY)
+//    private List<PostingMemberTag> postingMemberTagList = new ArrayList<>();
+//
+//    @OneToMany(mappedBy = "posting", fetch = FetchType.LAZY)
+//    private List<PostingImg> postingImgList = new ArrayList<>();
+//
+//    @OneToMany(mappedBy = "posting", fetch = FetchType.LAZY)
+//    private List<Comment> commentList = new ArrayList<>();
 
-    @OneToMany(mappedBy = "posting", fetch = FetchType.LAZY)
-    private List<PostingMemberTag> postingMemberTagList = new ArrayList<>();
-
-    @OneToMany(mappedBy = "posting", fetch = FetchType.LAZY)
-    private List<PostingImg> postingImgList = new ArrayList<>();
-
-    @OneToMany(mappedBy = "posting", fetch = FetchType.LAZY)
-    private List<Comment> commentList = new ArrayList<>();
+    @Builder
+    public Posting(String contents, Member member) {
+        this.contents = contents;
+        this.member = member;
+    }
 }

--- a/src/main/java/com/hanghae/instagram/posting/entity/PostingHashTag.java
+++ b/src/main/java/com/hanghae/instagram/posting/entity/PostingHashTag.java
@@ -1,5 +1,6 @@
 package com.hanghae.instagram.posting.entity;
 
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -14,9 +15,17 @@ public class PostingHashTag {
     private long id;
 
     @Column(nullable = false)
-    private String memberNickname;
+    private String hashtag;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "POSTING_ID", nullable = false)
     private Posting posting;
+
+    @Builder
+    public PostingHashTag(String hashtag, Posting posting) {
+        this.hashtag = hashtag;
+        this.posting = posting;
+
+//        posting.getPostingHashTagList().add(this);
+    }
 }

--- a/src/main/java/com/hanghae/instagram/posting/entity/PostingImg.java
+++ b/src/main/java/com/hanghae/instagram/posting/entity/PostingImg.java
@@ -1,5 +1,6 @@
 package com.hanghae.instagram.posting.entity;
 
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -19,12 +20,21 @@ public class PostingImg {
     private String postingImg;
 
     @Column(nullable = false)
-    private String postingImgNum;
+    private long postingImgNum;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "POSTING_ID", nullable = false)
     private Posting posting;
 
     @OneToMany(mappedBy = "postingImg", fetch = FetchType.LAZY)
-    private List<ImgMemberTag> imgMemberTagList = new ArrayList<>();
+    private List<PostingImgMemberTag> imgMemberTagList = new ArrayList<>();
+
+    @Builder
+    public PostingImg(String postingImg, long postingImgNum, Posting posting) {
+        this.postingImg = postingImg;
+        this.postingImgNum = postingImgNum;
+        this.posting = posting;
+
+//        posting.getPostingImgList().add(this);
+    }
 }

--- a/src/main/java/com/hanghae/instagram/posting/entity/PostingImgMemberTag.java
+++ b/src/main/java/com/hanghae/instagram/posting/entity/PostingImgMemberTag.java
@@ -1,5 +1,6 @@
 package com.hanghae.instagram.posting.entity;
 
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -8,7 +9,7 @@ import javax.persistence.*;
 @Getter
 @Entity
 @NoArgsConstructor
-public class ImgMemberTag {
+public class PostingImgMemberTag {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private long id;
@@ -26,4 +27,13 @@ public class ImgMemberTag {
     @JoinColumn(name = "POSTING_IMG_ID")
     private PostingImg postingImg;
 
+    @Builder
+    public PostingImgMemberTag(String memberNickname, long coordinateX, long coordinateY, PostingImg postingImg) {
+        this.memberNickname = memberNickname;
+        this.coordinateX = coordinateX;
+        this.coordinateY = coordinateY;
+        this.postingImg = postingImg;
+
+//        postingImg.getImgMemberTagList().add(this);
+    }
 }

--- a/src/main/java/com/hanghae/instagram/posting/entity/PostingMemberTag.java
+++ b/src/main/java/com/hanghae/instagram/posting/entity/PostingMemberTag.java
@@ -1,5 +1,6 @@
 package com.hanghae.instagram.posting.entity;
 
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -19,4 +20,12 @@ public class PostingMemberTag {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "POSTING_ID", nullable = false)
     private Posting posting;
+
+    @Builder
+    public PostingMemberTag(String memberNickname, Posting posting) {
+        this.memberNickname = memberNickname;
+        this.posting = posting;
+
+//        posting.getPostingMemberTagList().add(this);
+    }
 }

--- a/src/main/java/com/hanghae/instagram/posting/mapper/CreatePostingMapper.java
+++ b/src/main/java/com/hanghae/instagram/posting/mapper/CreatePostingMapper.java
@@ -1,0 +1,61 @@
+package com.hanghae.instagram.posting.mapper;
+
+import com.hanghae.instagram.common.exception.CustomException;
+import com.hanghae.instagram.member.entity.Member;
+import com.hanghae.instagram.member.repository.MemberRepository;
+import com.hanghae.instagram.posting.dto.createPosting.CreatePostingDto;
+import com.hanghae.instagram.posting.dto.createPosting.CreatePostingImgDto;
+import com.hanghae.instagram.posting.dto.createPosting.CreatePostingImgMemberTagDto;
+import com.hanghae.instagram.posting.entity.*;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+
+
+import static com.hanghae.instagram.common.exception.ErrorCode.MEMBER_NOT_FOUND;
+
+@Component
+@RequiredArgsConstructor
+public class CreatePostingMapper {
+    private final MemberRepository memberRepository;
+
+    private void memberTagValidator(String nickname) {
+        memberRepository.findByNickname(nickname)
+                .orElseThrow(() -> new CustomException(MEMBER_NOT_FOUND));
+    }
+
+    public Posting toEntity(CreatePostingDto createPostingDto, Member member) {
+        return Posting.builder()
+                .contents(createPostingDto.getContents())
+                .member(member)
+                .build();
+    }
+
+    public PostingImg toEntity(CreatePostingImgDto createPostingImgDto, Posting posting) {
+        return PostingImg.builder()
+                .posting(posting)
+                .postingImg(createPostingImgDto.getPostingImg())
+                .postingImgNum(createPostingImgDto.getPostingImgNum())
+                .build();
+    }
+
+    public PostingImgMemberTag toEntity(CreatePostingImgMemberTagDto createPostingImgMemberTagDto,
+                                        PostingImg postingImg) {
+        memberTagValidator(createPostingImgMemberTagDto.getNickname());
+
+        return PostingImgMemberTag.builder()
+                .postingImg(postingImg)
+                .memberNickname(createPostingImgMemberTagDto.getNickname())
+                .coordinateX(createPostingImgMemberTagDto.getCoordinateX())
+                .coordinateY(createPostingImgMemberTagDto.getCoordinateY())
+                .build();
+    }
+
+    public PostingMemberTag toEntity(String nickname, Posting posting) {
+        memberTagValidator(nickname);
+        return PostingMemberTag.builder()
+                .memberNickname(nickname)
+                .posting(posting)
+                .build();
+    }
+}

--- a/src/main/java/com/hanghae/instagram/posting/mapper/ShowPostingMapper.java
+++ b/src/main/java/com/hanghae/instagram/posting/mapper/ShowPostingMapper.java
@@ -1,0 +1,74 @@
+package com.hanghae.instagram.posting.mapper;
+
+import com.hanghae.instagram.posting.dto.showPosting.ShowPostingDto;
+import com.hanghae.instagram.posting.dto.showPosting.ShowPostingImgDto;
+import com.hanghae.instagram.posting.dto.showPosting.ShowPostingImgMemberTagDto;
+import com.hanghae.instagram.posting.entity.*;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class ShowPostingMapper {
+    private String dateTimeConverter(LocalDateTime time) {
+        String convertedTime = "";
+        Duration duration = Duration.between(time, LocalDateTime.now());
+        long differ = duration.getSeconds();
+        long sec = differ % 60;
+        long min = (differ / 60) % 60;
+        long hour = (differ / (60 * 60)) % 60;
+        long day = (differ / (60 * 60 * 60)) % 24;
+        long year = (differ / (60 * 60 * 60 * 24)) % 365;
+        if (year > 0) {
+            convertedTime = convertedTime + year + "년 ";
+        }
+        if (day > 0) {
+            convertedTime = convertedTime + day + "일 ";
+        }
+        if (hour > 0) {
+            convertedTime = convertedTime + hour + "시간 ";
+        }
+        if (min > 0) {
+            convertedTime = convertedTime + min + "분 ";
+        }
+        if (sec > 0) {
+            convertedTime = convertedTime + sec + "초 전";
+        }
+        return convertedTime;
+    }
+
+    public ShowPostingImgMemberTagDto toDto(PostingImgMemberTag postingImgMemberTag) {
+        return ShowPostingImgMemberTagDto.builder()
+                .nickname(postingImgMemberTag.getMemberNickname())
+                .coordinateX(postingImgMemberTag.getCoordinateX())
+                .coordinateY(postingImgMemberTag.getCoordinateY())
+                .build();
+    }
+    public ShowPostingImgDto toDto(PostingImg postingImg, List<ShowPostingImgMemberTagDto> memberTagList) {
+        return ShowPostingImgDto.builder()
+                .postingImg(postingImg.getPostingImg())
+                .postingImgNum(postingImg.getPostingImgNum())
+                .memberTagList(memberTagList)
+                .build();
+    }
+    public ShowPostingDto toDto(Posting posting, List<ShowPostingImgDto> imgList,
+                                List<String> hashtagList, List<String> membertagList) {
+        return ShowPostingDto.builder()
+                .id(posting.getId())
+                .contents(posting.getContents())
+                .likeCount(posting.getLikeCount())
+                .nickname(posting.getMember().getNickname())
+                .commentCount(11) // Comment 기능 구현 이후 로직 수정 필요
+                .postingLike(false) // Like 기능 구현 이후 로직 수정 필요
+                .hashtagList(hashtagList)
+                .membertagList(membertagList)
+                .createdAt(dateTimeConverter(posting.getCreatedAt()))
+                .modifiedAt(dateTimeConverter(posting.getModifiedAt()))
+                .imgList(imgList)
+                .build();
+    }
+}

--- a/src/main/java/com/hanghae/instagram/posting/repository/PostingHashTagRepository.java
+++ b/src/main/java/com/hanghae/instagram/posting/repository/PostingHashTagRepository.java
@@ -1,0 +1,10 @@
+package com.hanghae.instagram.posting.repository;
+
+import com.hanghae.instagram.posting.entity.PostingHashTag;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface PostingHashTagRepository extends JpaRepository<PostingHashTag, Long> {
+    List<PostingHashTag> findAllByPostingId(long postingId);
+}

--- a/src/main/java/com/hanghae/instagram/posting/repository/PostingImgMemberTagRepository.java
+++ b/src/main/java/com/hanghae/instagram/posting/repository/PostingImgMemberTagRepository.java
@@ -1,0 +1,10 @@
+package com.hanghae.instagram.posting.repository;
+
+import com.hanghae.instagram.posting.entity.PostingImgMemberTag;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface PostingImgMemberTagRepository extends JpaRepository<PostingImgMemberTag, Long> {
+    List<PostingImgMemberTag> findAllByPostingImgId(long id);
+}

--- a/src/main/java/com/hanghae/instagram/posting/repository/PostingImgRepository.java
+++ b/src/main/java/com/hanghae/instagram/posting/repository/PostingImgRepository.java
@@ -1,0 +1,10 @@
+package com.hanghae.instagram.posting.repository;
+
+import com.hanghae.instagram.posting.entity.PostingImg;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface PostingImgRepository extends JpaRepository<PostingImg, Long> {
+    List<PostingImg> findAllByPostingId(long id);
+}

--- a/src/main/java/com/hanghae/instagram/posting/repository/PostingMemberTagRepository.java
+++ b/src/main/java/com/hanghae/instagram/posting/repository/PostingMemberTagRepository.java
@@ -1,0 +1,10 @@
+package com.hanghae.instagram.posting.repository;
+
+import com.hanghae.instagram.posting.entity.PostingMemberTag;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface PostingMemberTagRepository extends JpaRepository<PostingMemberTag, Long> {
+    List<PostingMemberTag> findAllByPostingId(long postingId);
+}

--- a/src/main/java/com/hanghae/instagram/posting/repository/PostingRepository.java
+++ b/src/main/java/com/hanghae/instagram/posting/repository/PostingRepository.java
@@ -1,0 +1,11 @@
+package com.hanghae.instagram.posting.repository;
+
+import com.hanghae.instagram.posting.entity.Posting;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface PostingRepository extends JpaRepository<Posting, Long> {
+    List<Posting> findAllByOrderByLikeCount(Pageable pageable);
+}

--- a/src/main/java/com/hanghae/instagram/posting/service/PostingService.java
+++ b/src/main/java/com/hanghae/instagram/posting/service/PostingService.java
@@ -1,0 +1,129 @@
+package com.hanghae.instagram.posting.service;
+
+import com.hanghae.instagram.common.exception.CustomException;
+import com.hanghae.instagram.member.entity.Member;
+import com.hanghae.instagram.member.repository.MemberRepository;
+import com.hanghae.instagram.posting.dto.createPosting.CreatePostingDto;
+import com.hanghae.instagram.posting.dto.showPosting.ResponseShowPostingDto;
+import com.hanghae.instagram.posting.dto.showPosting.ShowPostingDto;
+import com.hanghae.instagram.posting.dto.showPosting.ShowPostingImgDto;
+import com.hanghae.instagram.posting.dto.showPosting.ShowPostingImgMemberTagDto;
+import com.hanghae.instagram.posting.entity.*;
+import com.hanghae.instagram.posting.mapper.CreatePostingMapper;
+import com.hanghae.instagram.posting.mapper.ShowPostingMapper;
+import com.hanghae.instagram.posting.repository.*;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.hanghae.instagram.common.exception.ErrorCode.MEMBER_NOT_FOUND;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class PostingService {
+    private final MemberRepository memberRepository;
+    private final PostingRepository postingRepository;
+    private final PostingHashTagRepository postingHashTagRepository;
+    private final PostingMemberTagRepository postingMemberTagRepository;
+    private final PostingImgRepository postingImgRepository;
+    private final PostingImgMemberTagRepository postingImgMemberTagRepository;
+
+    private final CreatePostingMapper createPostingMapper;
+    private final ShowPostingMapper showPostingMapper;
+
+    @Transactional
+    public void createPosting(CreatePostingDto createPostingDto, String email) {
+        // 1. email을 통해 로그인한 사용자의 정보 가져오기
+        Member member = memberRepository.findByEmail(email)
+                .orElseThrow(() -> new CustomException(MEMBER_NOT_FOUND));
+        // 2. 게시글 Entity 생성 및 저장
+        Posting posting = createPostingMapper.toEntity(createPostingDto, member);
+        postingRepository.save(posting);
+        // 3. 게시글 이미지 Entity 생성 및 저장
+        for (int i = 0; i < createPostingDto.getImgList().size(); i++) {
+            PostingImg postingImg = createPostingMapper.toEntity(createPostingDto.getImgList().get(i), posting);
+            postingImgRepository.save(postingImg);
+
+            // 4. 이미지 회원태그 Entity 생성 및 저장
+            for (int j = 0; j < createPostingDto.getImgList().get(i).getMemberTagList().size(); j++) {
+                PostingImgMemberTag postingImgMemberTag = createPostingMapper.toEntity(
+                        createPostingDto.getImgList().get(i).getMemberTagList().get(j),
+                        postingImg
+                );
+                postingImgMemberTagRepository.save(postingImgMemberTag);
+            }
+        }
+        // 5. 게시글 회원태그 Entity 생성
+        for (int i = 0; i < createPostingDto.getMembertagList().size(); i++) {
+            PostingMemberTag postingMemberTag = createPostingMapper.toEntity(
+                    createPostingDto.getMembertagList().get(i),
+                    posting
+            );
+            postingMemberTagRepository.save(postingMemberTag);
+        }
+        // 6. 게시글 해쉬태그 Entity 생성
+        for (int i = 0; i < createPostingDto.getHashtagList().size(); i++) {
+            PostingHashTag postingHashTag = new PostingHashTag(
+                    createPostingDto.getHashtagList().get(i),
+                    posting
+            );
+            postingHashTagRepository.save(postingHashTag);
+        }
+    }
+
+    @Transactional(readOnly = true)
+    public List<ResponseShowPostingDto> showPosting(Pageable pageable){
+        List<ResponseShowPostingDto> responseShowPostingDtoList = new ArrayList<>();
+
+        List<Posting> postingList = postingRepository.findAllByOrderByLikeCount(pageable);
+        List<ShowPostingDto> showPostingDtoList = new ArrayList<>();
+        for (Posting posting : postingList) {
+            // 1. HashTag 정보 가져오기
+            List<PostingHashTag> postingHashTagList
+                    = postingHashTagRepository.findAllByPostingId(posting.getId());
+            List<String> hashtagList = new ArrayList<>();
+            for (PostingHashTag postingHashTag : postingHashTagList) {
+                hashtagList.add(postingHashTag.getHashtag());
+            }
+
+            // 2. MemberTag 정보 가져오기
+            List<PostingMemberTag> postingMemberTagList
+                    = postingMemberTagRepository.findAllByPostingId(posting.getId());
+            List<String> membertagList = new ArrayList<>();
+            for (PostingMemberTag postingMemberTag : postingMemberTagList) {
+                membertagList.add(postingMemberTag.getMemberNickname());
+            }
+
+            // 3. PostingImg 정보 가져오기
+            List<PostingImg> postingImgList = postingImgRepository.findAllByPostingId(posting.getId());
+            List<ShowPostingImgDto> imgList = new ArrayList<>();
+            for (PostingImg postingImg : postingImgList) {
+                List<PostingImgMemberTag> postingImgMemberTagList
+                        = postingImgMemberTagRepository.findAllByPostingImgId(postingImg.getId());
+                List<ShowPostingImgMemberTagDto> showPostingImgMemberTagDtoList = new ArrayList<>();
+                for (PostingImgMemberTag postingImgMemberTag : postingImgMemberTagList) {
+                    showPostingImgMemberTagDtoList.add(
+                            showPostingMapper.toDto(postingImgMemberTag)
+                    );
+                }
+                imgList.add(showPostingMapper.toDto(postingImg, showPostingImgMemberTagDtoList));
+            }
+
+            // 4. ShowPostingDto 형식으로 변환하고 리스트에 추가하기
+            showPostingDtoList.add(showPostingMapper.toDto(posting, imgList, hashtagList, membertagList));
+        }
+
+        for (ShowPostingDto showPostingDto : showPostingDtoList) {
+            responseShowPostingDtoList.add(showPostingDto.toResponse());
+        }
+
+        return responseShowPostingDtoList;
+    }
+
+}

--- a/src/main/resources/application-h2.properties
+++ b/src/main/resources/application-h2.properties
@@ -1,0 +1,9 @@
+spring.h2.console.enabled=true
+spring.datasource.url=jdbc:h2:mem:db;MODE=MYSQL;
+spring.datasource.username=sa
+spring.datasource.password=
+
+logging.level.org.hibernate.SQL=DEBUG
+spring.jpa.properties.hibernate.format_sql=true
+spring.jpa.properties.hibernate.highlight_sql=true
+logging.level.org.hibernate.type.descriptor.sql.BasicBinder=TRACE

--- a/src/main/resources/json/memberData.json
+++ b/src/main/resources/json/memberData.json
@@ -1,0 +1,27 @@
+[
+  {
+    "email": "user1@test",
+    "nickname": "user1",
+    "password": "qwe123!@#"
+  },
+  {
+    "email": "user2@test",
+    "nickname": "user2",
+    "password": "qwe123!@#"
+  },
+  {
+    "email": "user3@test",
+    "nickname": "user3",
+    "password": "qwe123!@#"
+  },
+  {
+    "email": "user4@test",
+    "nickname": "user4",
+    "password": "qwe123!@#"
+  },
+  {
+    "email": "user5@test",
+    "nickname": "user5",
+    "password": "qwe123!@#"
+  }
+]


### PR DESCRIPTION
## PR 체크사항
PR이 다음 사항을 만족하는지 확인해주세요.

<!-- 
체크하려면 괄호 안에 "x"를 입력하세요. 
각 규칙은 Convention 문서에 있습니다.
PR 제목에 쓰는 prefix는 다음과 같습니다.
🚀 Release
🐛 Fix
✨ Feat
📝 Doc
♻️ Refactor
🔧 Chore
⏪️ Revert
🧪 Test
🎉 Init
-->

- [x] 커밋 제목 규칙
- [x] 커밋 메시지 작성 가이드라인
- [x] 라벨, 담당자, 리뷰어 지정


## PR 타입
어떤 유형의 PR인지 체크해주세요.

<!-- 체크하려면 괄호 안에 "x"를 입력하세요. -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:


## PR 설명 & 작업 사항
> 다시는 이렇게 한번에 올리지 않겠습니다...... 죄송합니다.....😕
### 1. Mock Data 구성을 위한 JSON 파일 생성 및 Application 파일 수정
현재 멤버 회원가입에 한해서 JSON 파일을 이용해 Mock Data 를 구성할 수 있도록 설정해두었습니다. 원빈 매니저님이 알려주신 방법으로 했는데, 각 도메인별 로직이 변경될 때마다 에러를 뱉을 확률이 좀 많습니다 ㅠ 걸리적 거리시면 그냥 주석처리 부탁드리겠습니다! PR 할때마다 바꾸신 로직 맞춰서 틈틈히 바꿔놓을게요
### 2. H2 Test를 위한 application.properties 생성
H2 Test를 위해서 `application-h2.properties` 생성했습니다. 혹시 사용하실 분들은 `application.properties`에서 `spring.profiles.active=h2` 로 바꿔주세요!
### 3. Posting 관련 기능 구현
#### 3-1. Entity 연관관계 수정
기존 양방향 연관관계로 되어있던 Entity 중에서, Posting 관련 Entity들을 단방향 연관관계로 수정하였습니다. 민아님이 말씀하셨던 부분 고민하다보니, 굳이 `Posting`이 다른 Entity에 대한 정보를 들고 있을 필요가 없겠다 생각이 들었습니다. 혹시 다른 도메인에서 양방향 연관관계가 필요하시면, 말씀해주시면 수정해놓겟습니다. 양방향을 없애니까 확실히 쿼리가 줄어든 느낌입니다! 세보진 않았지만......
추가적으로, 연관 관계 수정 및 DeepCopy 적용 과정에서 단순 조회임에도 불구하고 Service Layer가 매우 비대해졌습니다. Service Layer가 비대해지는 건 크게 문제가 될게 없다고 하지만, 뭔가 불편해서 깔끔하게 정리할 수 있으면 정리해보겠습니다.
#### 3-2. DTO
Posting 기능에서 DTO를 하도 많이 사용해서, 임의로 Package를 나누었습니다. Package는 제공하는 서비스(Posting 생성, Posting 단일 조회 등)에 맞추어 구분했습니다.
기본적으로 DTO<->DTO 변환은 `@Builder`를 사용했고, 각  DTO 객체의 무결성을 보장하기 위해 List들은 전부 Deep Copy하는 방향으로 구현했습니다. 개인적으로 `Request` 혹은 `Response`가 붙은 DTO는 Service Layer에 들어오면 안된다고 생각이 들어, 각 서비스에서 사용하는 형태로 Request 혹은 Response DTO를 변환해 사용했습니다.
#### 3-3. Mapper
Mapper 역시 `@Builder`를 통해 구현했고, 너무 많은 Entity 덕에 Mapper가 터질 지경이 되어 서비스 별로 분리하였습니다. 분리한 기준은 DTO Pacakge와 같습니다.
#### 3-4. 게시물 상세 조회, 삭제 기능
Comment 관련된 로직이 추가되어야해서, Comment 관련 작업이 끝나면 빠르게 추가하겠습니다.
### 4. 페이징 적용
Pageable 사용해서 간단하게 페이징 구현했습니다. 다음과 같이 요청하시면 됩니다.
`{{Address}}/api/posting?page=1&size=5`

## 변경로직
- Posting 관련 Entity의 양방향 연관관계 삭제.

close #28
