### PR TITLE
✨ Feat: 좋아요 기능 

### DIFF
--- a/src/main/java/com/hanghae/instagram/comment/entity/Comment.java
+++ b/src/main/java/com/hanghae/instagram/comment/entity/Comment.java
@@ -1,9 +1,14 @@
 package com.hanghae.instagram.comment.entity;
 
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
 import javax.persistence.*;
 import java.util.List;
 
 @Entity
+@Getter
+@NoArgsConstructor
 public class Comment {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -21,4 +26,7 @@ public class Comment {
     private List<Comment> commentList;
 
 
+    public void updateLikeCount(int likeCount){
+        this.likeCount = likeCount;
+    }
 }

--- a/src/main/java/com/hanghae/instagram/common/exception/ErrorCode.java
+++ b/src/main/java/com/hanghae/instagram/common/exception/ErrorCode.java
@@ -15,6 +15,8 @@ public enum ErrorCode {
     INCORRECT_PASSWORD(BAD_REQUEST, "비밀번호가 일치하지 않습니다.", OK),
     REQUIRED_ALL(BAD_REQUEST,"모든 항목이 필수값입니다.", OK), // 에러코드 고민해봐야 겠음
 
+    DUPLICATE_LIKE_CANCEL(BAD_REQUEST, "이미 좋아요가 취소 되었습니다.", OK),
+
     /* 401 UNAUTHORIZED : 인증되지 않은 사용자 */
     JWT_NOT_FOUND(UNAUTHORIZED, "토큰이 존재하지 않습니다.", UNAUTHORIZED),
     INVALID_JWT(UNAUTHORIZED, "유효하지 않은 토큰입니다.", UNAUTHORIZED),
@@ -25,7 +27,7 @@ public enum ErrorCode {
 
     /* 404 NOT_FOUND : Resource 를 찾을 수 없음 */
     MEMBER_NOT_FOUND(NOT_FOUND, "해당 유저 정보를 찾을 수 없습니다", NOT_FOUND),
-    COMMENT_NOT_FOUND(NOT_FOUND, "해당 댓글을 찾을 수 없습니다", NOT_FOUND),
+    COMMENT_NOT_FOUND(NOT_FOUND, "해당 댓글을 찾을 수 없습니다", OK),
     FORUM_NOT_FOUND(NOT_FOUND, "해당 게시글을 찾을 수 없습니다", NOT_FOUND),
 
     /* 409 CONFLICT : Resource 의 현재 상태와 충돌. 보통 중복된 데이터 존재 */

--- a/src/main/java/com/hanghae/instagram/common/response/SuccessCode.java
+++ b/src/main/java/com/hanghae/instagram/common/response/SuccessCode.java
@@ -11,7 +11,11 @@ import static org.springframework.http.HttpStatus.OK;
 public enum SuccessCode {
     // User
     SIGNUP_USER_SUCCESS(OK, "회원 가입 성공"),
-    LOGIN_USER_SUCCESS(OK, "유저 로그인 성공");
+    LOGIN_USER_SUCCESS(OK, "유저 로그인 성공"),
+
+    // Like
+    LIKE_SUCCESS(OK, "좋아요 성공"),
+    LIKE_CANCEL_SUCCESS(OK, "좋아요 취소 성공");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/hanghae/instagram/like/controller/LikeController.java
+++ b/src/main/java/com/hanghae/instagram/like/controller/LikeController.java
@@ -1,0 +1,50 @@
+package com.hanghae.instagram.like.controller;
+
+import com.hanghae.instagram.common.response.DataResponse;
+
+import com.hanghae.instagram.like.dto.RequestLikeDto;
+import com.hanghae.instagram.like.dto.ResponseLikeDto;
+import com.hanghae.instagram.like.service.LikeService;
+
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import static com.hanghae.instagram.common.response.SuccessCode.LIKE_CANCEL_SUCCESS;
+import static com.hanghae.instagram.common.response.SuccessCode.LIKE_SUCCESS;
+
+
+@RestController
+@RequestMapping("/api/like")
+@RequiredArgsConstructor
+public class LikeController {
+
+    private LikeService likeService;
+
+    @PostMapping("/posting/{postingId}")
+    public ResponseEntity<DataResponse<ResponseLikeDto>> changePostingLikeState(@PathVariable Long postingId, @RequestBody RequestLikeDto requestLike) {
+        String nickname = "mina"; // 임시
+        ResponseLikeDto responseLike = likeService.changePostingLikeState(requestLike, postingId, nickname);
+
+        if (responseLike.isLike()) {
+            return DataResponse.toResponseEntity(LIKE_SUCCESS, responseLike);
+        }
+        return DataResponse.toResponseEntity(LIKE_CANCEL_SUCCESS, responseLike);
+    }
+
+    @PostMapping("/comment/{commentId}")
+    public ResponseEntity<DataResponse<ResponseLikeDto>> changeCommentLikeState(@PathVariable Long commentId, @RequestBody RequestLikeDto requestLike) {
+        String nickname = "mina"; // 임시
+        ResponseLikeDto responseLike = likeService.changeCommentLikeState(requestLike, commentId, nickname);
+
+        if (responseLike.isLike()) {
+            return DataResponse.toResponseEntity(LIKE_SUCCESS, responseLike);
+        }
+        return DataResponse.toResponseEntity(LIKE_CANCEL_SUCCESS, responseLike);
+    }
+}

--- a/src/main/java/com/hanghae/instagram/like/dto/RequestLikeDto.java
+++ b/src/main/java/com/hanghae/instagram/like/dto/RequestLikeDto.java
@@ -1,0 +1,12 @@
+package com.hanghae.instagram.like.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class RequestLikeDto {
+
+    private boolean like;
+
+}

--- a/src/main/java/com/hanghae/instagram/like/dto/ResponseLikeDto.java
+++ b/src/main/java/com/hanghae/instagram/like/dto/ResponseLikeDto.java
@@ -1,0 +1,17 @@
+package com.hanghae.instagram.like.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class ResponseLikeDto {
+
+    private boolean like;
+    private int likeCount;
+
+    public ResponseLikeDto(boolean like, int likeCount) {
+        this.like = like;
+        this.likeCount = likeCount;
+    }
+}

--- a/src/main/java/com/hanghae/instagram/like/entity/CommentLike.java
+++ b/src/main/java/com/hanghae/instagram/like/entity/CommentLike.java
@@ -1,10 +1,19 @@
 package com.hanghae.instagram.like.entity;
 
 import com.hanghae.instagram.comment.entity.Comment;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
-import javax.persistence.*;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.ManyToOne;
 
+@Getter
 @Entity
+@NoArgsConstructor
 public class CommentLike {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -12,9 +21,12 @@ public class CommentLike {
 
     private String nickname;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "COMMENT_ID")
+    @ManyToOne(fetch = FetchType.EAGER)
     private Comment comment;
 
+    public CommentLike(String nickname, Comment comment) {
+        this.nickname = nickname;
+        this.comment = comment;
+    }
 
 }

--- a/src/main/java/com/hanghae/instagram/like/entity/PostingLike.java
+++ b/src/main/java/com/hanghae/instagram/like/entity/PostingLike.java
@@ -1,10 +1,14 @@
 package com.hanghae.instagram.like.entity;
 
 import com.hanghae.instagram.posting.entity.Posting;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
 
+@Getter
 @Entity
+@NoArgsConstructor
 public class PostingLike {
 
     @Id
@@ -13,11 +17,11 @@ public class PostingLike {
 
     private String nickname;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "POSTING_ID")
+    @ManyToOne(fetch = FetchType.EAGER)
     private Posting posting;
 
-
-
-
+    public PostingLike(String nickname, Posting posting) {
+        this.nickname = nickname;
+        this.posting = posting;
+    }
 }

--- a/src/main/java/com/hanghae/instagram/like/repository/CommentLikeRepository.java
+++ b/src/main/java/com/hanghae/instagram/like/repository/CommentLikeRepository.java
@@ -1,0 +1,11 @@
+package com.hanghae.instagram.like.repository;
+
+import com.hanghae.instagram.like.entity.CommentLike;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface CommentLikeRepository extends JpaRepository<CommentLike, Long> {
+
+    Optional<CommentLike> findCommentLikeByNicknameAndCommentId(String nickname, Long commentId);
+}

--- a/src/main/java/com/hanghae/instagram/like/repository/PostingLikeRepository.java
+++ b/src/main/java/com/hanghae/instagram/like/repository/PostingLikeRepository.java
@@ -1,0 +1,12 @@
+package com.hanghae.instagram.like.repository;
+
+import com.hanghae.instagram.like.entity.PostingLike;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface PostingLikeRepository extends JpaRepository<PostingLike, Long> {
+
+    Optional<PostingLike> findPostingLikeByNicknameAndPostingId(String nickname, Long postingId);
+
+}

--- a/src/main/java/com/hanghae/instagram/like/service/LikeService.java
+++ b/src/main/java/com/hanghae/instagram/like/service/LikeService.java
@@ -1,0 +1,95 @@
+package com.hanghae.instagram.like.service;
+
+import com.hanghae.instagram.comment.entity.Comment;
+import com.hanghae.instagram.comment.repository.CommentRepository;
+import com.hanghae.instagram.common.exception.CustomException;
+
+import com.hanghae.instagram.like.dto.RequestLikeDto;
+import com.hanghae.instagram.like.dto.ResponseLikeDto;
+import com.hanghae.instagram.like.entity.CommentLike;
+import com.hanghae.instagram.like.entity.PostingLike;
+import com.hanghae.instagram.like.repository.CommentLikeRepository;
+import com.hanghae.instagram.like.repository.PostingLikeRepository;
+
+import com.hanghae.instagram.posting.entity.Posting;
+import com.hanghae.instagram.posting.entity.PostingRepository;
+
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.stereotype.Service;
+
+import org.springframework.transaction.annotation.Transactional;
+
+import static com.hanghae.instagram.common.exception.ErrorCode.COMMENT_NOT_FOUND;
+import static com.hanghae.instagram.common.exception.ErrorCode.DUPLICATE_LIKE_CANCEL;
+import static com.hanghae.instagram.common.exception.ErrorCode.FORUM_NOT_FOUND;
+
+@Service
+@RequiredArgsConstructor
+public class LikeService {
+
+    private PostingLikeRepository postingLikeRepository;
+    private CommentLikeRepository commentLikeRepository;
+    private CommentRepository commentRepository;
+    private PostingRepository postingRepository;
+
+    @Transactional
+    public ResponseLikeDto changePostingLikeState(RequestLikeDto requestLike, Long postingId, String nickname) {
+
+        boolean like = requestLike.isLike();
+
+        // 좋아요 취소
+        if (like) {
+            PostingLike postingLikeFind = postingLikeRepository.findPostingLikeByNicknameAndPostingId(nickname, postingId).orElseThrow(() -> new CustomException(DUPLICATE_LIKE_CANCEL));
+
+            Posting posting = postingLikeFind.getPosting();
+            int currentLikeCount = posting.getLikeCount() - 1;
+            posting.updateLikeCount(currentLikeCount);
+
+            postingLikeRepository.deleteById(postingLikeFind.getId());
+            return new ResponseLikeDto(false, currentLikeCount);
+        }
+
+        // 좋아요
+        Posting postingFind = postingRepository.findById(postingId).orElseThrow(() -> new CustomException(FORUM_NOT_FOUND));
+
+        PostingLike newPostingLike = new PostingLike(nickname, postingFind);
+        postingLikeRepository.save(newPostingLike);
+        int currentLikeCount = postingFind.getLikeCount() + 1;
+
+        postingFind.updateLikeCount(currentLikeCount);
+
+        return new ResponseLikeDto(true, currentLikeCount);
+    }
+
+
+    @Transactional
+    public ResponseLikeDto changeCommentLikeState(RequestLikeDto requestLike, Long commentId, String nickname) {
+
+        boolean like = requestLike.isLike();
+
+        // 좋아요 취소
+        if (like) {
+            CommentLike commentLikeFind = commentLikeRepository.findCommentLikeByNicknameAndCommentId(nickname, commentId).orElseThrow(() -> new CustomException(DUPLICATE_LIKE_CANCEL));
+
+            Comment comment = commentLikeFind.getComment();
+            int currentLikeCount = comment.getLikeCount() - 1;
+            comment.updateLikeCount(currentLikeCount);
+
+            commentLikeRepository.deleteById(commentLikeFind.getId());
+            return new ResponseLikeDto(false, currentLikeCount);
+        }
+
+        // 좋아요
+        Comment commentFind = commentRepository.findById(commentId).orElseThrow(() -> new CustomException(COMMENT_NOT_FOUND));
+
+        CommentLike newCommentLike = new CommentLike(nickname, commentFind);
+        commentLikeRepository.save(newCommentLike);
+        int currentLikeCount = commentFind.getLikeCount() + 1;
+
+        commentFind.updateLikeCount(currentLikeCount);
+
+        return new ResponseLikeDto(true, currentLikeCount);
+    }
+
+}

--- a/src/main/java/com/hanghae/instagram/like/service/LikeService.java
+++ b/src/main/java/com/hanghae/instagram/like/service/LikeService.java
@@ -12,7 +12,7 @@ import com.hanghae.instagram.like.repository.CommentLikeRepository;
 import com.hanghae.instagram.like.repository.PostingLikeRepository;
 
 import com.hanghae.instagram.posting.entity.Posting;
-import com.hanghae.instagram.posting.entity.PostingRepository;
+import com.hanghae.instagram.posting.repository.PostingRepository;
 
 import lombok.RequiredArgsConstructor;
 

--- a/src/main/java/com/hanghae/instagram/like/service/LikeService.java
+++ b/src/main/java/com/hanghae/instagram/like/service/LikeService.java
@@ -40,7 +40,8 @@ public class LikeService {
 
         // 좋아요 취소
         if (like) {
-            PostingLike postingLikeFind = postingLikeRepository.findPostingLikeByNicknameAndPostingId(nickname, postingId).orElseThrow(() -> new CustomException(DUPLICATE_LIKE_CANCEL));
+            PostingLike postingLikeFind = postingLikeRepository.findPostingLikeByNicknameAndPostingId(nickname, postingId)
+                    .orElseThrow(() -> new CustomException(DUPLICATE_LIKE_CANCEL));
 
             Posting posting = postingLikeFind.getPosting();
             int currentLikeCount = posting.getLikeCount() - 1;
@@ -51,7 +52,8 @@ public class LikeService {
         }
 
         // 좋아요
-        Posting postingFind = postingRepository.findById(postingId).orElseThrow(() -> new CustomException(FORUM_NOT_FOUND));
+        Posting postingFind = postingRepository.findById(postingId)
+                .orElseThrow(() -> new CustomException(FORUM_NOT_FOUND));
 
         PostingLike newPostingLike = new PostingLike(nickname, postingFind);
         postingLikeRepository.save(newPostingLike);
@@ -70,7 +72,8 @@ public class LikeService {
 
         // 좋아요 취소
         if (like) {
-            CommentLike commentLikeFind = commentLikeRepository.findCommentLikeByNicknameAndCommentId(nickname, commentId).orElseThrow(() -> new CustomException(DUPLICATE_LIKE_CANCEL));
+            CommentLike commentLikeFind = commentLikeRepository.findCommentLikeByNicknameAndCommentId(nickname, commentId)
+                    .orElseThrow(() -> new CustomException(DUPLICATE_LIKE_CANCEL));
 
             Comment comment = commentLikeFind.getComment();
             int currentLikeCount = comment.getLikeCount() - 1;
@@ -81,7 +84,8 @@ public class LikeService {
         }
 
         // 좋아요
-        Comment commentFind = commentRepository.findById(commentId).orElseThrow(() -> new CustomException(COMMENT_NOT_FOUND));
+        Comment commentFind = commentRepository.findById(commentId)
+                .orElseThrow(() -> new CustomException(COMMENT_NOT_FOUND));
 
         CommentLike newCommentLike = new CommentLike(nickname, commentFind);
         commentLikeRepository.save(newCommentLike);

--- a/src/main/java/com/hanghae/instagram/posting/entity/Posting.java
+++ b/src/main/java/com/hanghae/instagram/posting/entity/Posting.java
@@ -40,4 +40,8 @@ public class Posting extends Timestamped {
 
     @OneToMany(mappedBy = "posting", fetch = FetchType.LAZY)
     private List<Comment> commentList = new ArrayList<>();
+
+    public void updateLikeCount(int likeCount){
+        this.likeCount = likeCount;
+    }
 }


### PR DESCRIPTION
## PR 체크사항
PR이 다음 사항을 만족하는지 확인해주세요.

<!-- 
체크하려면 괄호 안에 "x"를 입력하세요. 
각 규칙은 Convention 문서에 있습니다.
PR 제목에 쓰는 prefix는 다음과 같습니다.
🚀 Release
🐛 Fix
✨ Feat
📝 Doc
♻️ Refactor
🔧 Chore
⏪️ Revert
🧪 Test
🎉 Init
-->

- [x] 커밋 제목 규칙
- [x] 커밋 메시지 작성 가이드라인
- [x] 라벨, 담당자, 리뷰어 지정


## PR 타입
어떤 유형의 PR인지 체크해주세요.

<!-- 체크하려면 괄호 안에 "x"를 입력하세요. -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:


## PR 설명
게시글 및 댓글 좋아요, 좋아요 취소 기능 

<br/>

❗️ 고민하고 적용해본 사항 

#### 1. Mapper 폴더 및 파일 생성 하지 않았습니다. 
그 이유는 현재 좋아요 기능을 구현하기 위해 필요한 entity 및 dto의 필드의 수는 작습니다. 따라서 오히려 비효율적이라는 판단을 내리고 각 클래스의 생성자로만 생성해서 사용했습니다.

<br/>

#### 2. 좋아요 기능의 책임은 어디까지?? 
좋아요 기능을 구현하면서 어디까지를 생각하고 로직을 짜야 하나 고민해보았습니다. 

2-1. 댓글 좋아요를 하는 시점에서 게시글이 없는거 까지 확인해야 할까? 
댓글은 게시글이 삭제될 경우 삭제됩니다. 그래서 댓글이 있는지만 확인하는 로직으로 구현 했습니다. 

2-2. 혹시나 모를 댓글 중복 좋아요를 확인해야 할까?
현재 프론트에서 보내주는 좋아요 상태에 따라 로직이 구현되고 → 응답으로 좋아요의 변환된 상태를 반환합니다. 
이런 경우에 중복 좋아요가 될 가능성은 현저히 낮다고 판단 하였고, 이 낮은 가능성을 위해 모든 좋아요 시, 검색을 한번 더 해야 하는게 맞을까? 하는 고민에 중복 좋아요 확인 로직을 넣지 않았습니다.

2-3. 좋아요 삭제시 댓글이 삭제 됐는지 여부 판단
댓글이 삭제될 경우 관련 좋아요도 삭제 됩니다. 따라서 좋아요가 남아있을 경우 댓글이 삭제 되지 않은 경우로 판단하여 로직을 구현하였습니다.

위의 상황들을 적용함으로써 물론 로직이 촘촘하지 않지만, 에러가 발생할 확률은 매우 적다고 판단하였고, 오히려 수많은 좋아요를 누르는 상황에서 db 조회를 줄어야 한다고 판단하였습니다. 물론 생각과 다르게 여러 에러가 날 수 있지만 도전해보았습니다!

<br/>

#### 3. PostingLike, CommentLike Entity 연관관계 설정 및 fetch 타입 
좋아요는 각 게시글, 댓글 좋아요 테이블과 각 게시글, 댓글 테이블의 likeCount 필드와도 연관되어있습니다. 따라서 좋아요 entity에 연관관계를 주어 한번에 불러와 likeCount를 컨트롤 할 수 있도록 하였습니다.(조회 시점을 생각하고 연관관계를 건다는 기술 매니저님의 말을 깨달았습니다!) 
또한 fetch를 FetchType.EAGER로 주었습니다. 현재 로직 상에서는 ex) PositngLike entity와 그 안에 Posting 객체를 항상 같이 쓰는 로직만 있어 EAGER가 더욱 효율적이지 않을까하는 생각을 했습니다.

<br/>

## 작업사항
- 좋아요, 좋아요 취소 기능 구현
- repository nickname과 postingId, commentId로 찾는 메소드 생성
- 에러 및 성공 메시지 생성 
- entity Fetch 타입 변경 및 생성자 생성

<br/>

*여러 생각을 하느라 늦었습니다. 오늘은 더욱 달려보겠습니다!!