### PR TITLE
✨ Feat: 팔로우 기능

### DIFF
--- a/src/main/java/com/hanghae/instagram/common/response/SuccessCode.java
+++ b/src/main/java/com/hanghae/instagram/common/response/SuccessCode.java
@@ -14,6 +14,10 @@ public enum SuccessCode {
     LIKE_SUCCESS(OK, "좋아요 성공"),
     LIKE_CANCEL_SUCCESS(OK, "좋아요 취소 성공"),
 
+    // Follow
+    FOLLOW_SUCCESS(OK, "팔로우 성공"),
+    UNFOLLOW_SUCCESS(OK, "언팔로우 성공"),
+
     CREATE_POSTING_SUCCESS(OK, "포스팅 등록 성공"),
     SHOW_POSTING_SUCCESS(OK, "전체 포스팅 조회 성공"),
     CREATE_COMMENT_SUCCESS(OK, "댓글 작성 성공");

--- a/src/main/java/com/hanghae/instagram/follow/controller/FollowController.java
+++ b/src/main/java/com/hanghae/instagram/follow/controller/FollowController.java
@@ -1,0 +1,36 @@
+package com.hanghae.instagram.follow.controller;
+
+import com.hanghae.instagram.common.response.DataResponse;
+import com.hanghae.instagram.follow.dto.RequestFollowDto;
+import com.hanghae.instagram.follow.dto.ResponseFollowDto;
+import com.hanghae.instagram.follow.service.FollowService;
+
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.http.ResponseEntity;
+
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import static com.hanghae.instagram.common.response.SuccessCode.FOLLOW_SUCCESS;
+import static com.hanghae.instagram.common.response.SuccessCode.UNFOLLOW_SUCCESS;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("api/follow")
+public class FollowController {
+
+    private final FollowService followService;
+
+    @PutMapping("")
+    public ResponseEntity<DataResponse<ResponseFollowDto>> followAndUnfollow(@RequestBody RequestFollowDto follow){
+
+        boolean newFollowState = followService.doFollowAndUnfollow(follow);
+
+        if(newFollowState) {
+            return DataResponse.toResponseEntity(FOLLOW_SUCCESS, new ResponseFollowDto(true));
+        } return DataResponse.toResponseEntity(UNFOLLOW_SUCCESS, new ResponseFollowDto(false));
+    }
+}

--- a/src/main/java/com/hanghae/instagram/follow/dto/RequestFollowDto.java
+++ b/src/main/java/com/hanghae/instagram/follow/dto/RequestFollowDto.java
@@ -1,0 +1,13 @@
+package com.hanghae.instagram.follow.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class RequestFollowDto {
+
+    private boolean followState;
+    private String following;
+    private String follower;
+}

--- a/src/main/java/com/hanghae/instagram/follow/dto/ResponseFollowDto.java
+++ b/src/main/java/com/hanghae/instagram/follow/dto/ResponseFollowDto.java
@@ -1,0 +1,15 @@
+package com.hanghae.instagram.follow.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class ResponseFollowDto {
+
+    private boolean followState;
+
+    public ResponseFollowDto(boolean followState) {
+        this.followState = followState;
+    }
+}

--- a/src/main/java/com/hanghae/instagram/follow/entity/Follow.java
+++ b/src/main/java/com/hanghae/instagram/follow/entity/Follow.java
@@ -1,0 +1,35 @@
+package com.hanghae.instagram.follow.entity;
+
+import com.hanghae.instagram.member.entity.Member;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.EmbeddedId;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.ManyToOne;
+import javax.persistence.MapsId;
+
+@Entity
+@NoArgsConstructor
+@Getter
+public class Follow {
+
+    @EmbeddedId
+    private FollowCompositeKey id;
+
+    @MapsId("followerId")
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Member follower;
+
+    @MapsId("followingId")
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Member following;
+
+    public Follow(FollowCompositeKey id, Member follower, Member following) {
+        this.id = id;
+        this.follower = follower;
+        this.following = following;
+    }
+}

--- a/src/main/java/com/hanghae/instagram/follow/entity/Follow.java
+++ b/src/main/java/com/hanghae/instagram/follow/entity/Follow.java
@@ -19,17 +19,17 @@ public class Follow {
     @EmbeddedId
     private FollowCompositeKey id;
 
-    @MapsId("followerId")
-    @ManyToOne(fetch = FetchType.LAZY)
-    private Member follower;
-
     @MapsId("followingId")
     @ManyToOne(fetch = FetchType.LAZY)
     private Member following;
 
-    public Follow(FollowCompositeKey id, Member follower, Member following) {
+    @MapsId("followerId")
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Member follower;
+
+    public Follow(FollowCompositeKey id, Member following, Member follower) {
         this.id = id;
-        this.follower = follower;
         this.following = following;
+        this.follower = follower;
     }
 }

--- a/src/main/java/com/hanghae/instagram/follow/entity/FollowCompositeKey.java
+++ b/src/main/java/com/hanghae/instagram/follow/entity/FollowCompositeKey.java
@@ -11,12 +11,12 @@ import java.io.Serializable;
 public class FollowCompositeKey implements Serializable {
 
     @Column(nullable = false)
-    private Long followerId;
-    @Column(nullable = false)
     private Long followingId;
+    @Column(nullable = false)
+    private Long followerId;
 
-    public FollowCompositeKey(Long followerId, Long followingId){
-        this.followerId = followerId;
+    public FollowCompositeKey(Long followingId, Long followerId){
         this.followingId = followingId;
+        this.followerId = followerId;
     }
 }

--- a/src/main/java/com/hanghae/instagram/follow/entity/FollowCompositeKey.java
+++ b/src/main/java/com/hanghae/instagram/follow/entity/FollowCompositeKey.java
@@ -1,0 +1,22 @@
+package com.hanghae.instagram.follow.entity;
+
+import lombok.NoArgsConstructor;
+
+import javax.persistence.Column;
+import javax.persistence.Embeddable;
+import java.io.Serializable;
+
+@Embeddable
+@NoArgsConstructor
+public class FollowCompositeKey implements Serializable {
+
+    @Column(nullable = false)
+    private Long followerId;
+    @Column(nullable = false)
+    private Long followingId;
+
+    public FollowCompositeKey(Long followerId, Long followingId){
+        this.followerId = followerId;
+        this.followingId = followingId;
+    }
+}

--- a/src/main/java/com/hanghae/instagram/follow/repository/FollowRepository.java
+++ b/src/main/java/com/hanghae/instagram/follow/repository/FollowRepository.java
@@ -1,0 +1,9 @@
+package com.hanghae.instagram.follow.repository;
+
+import com.hanghae.instagram.follow.entity.Follow;
+import com.hanghae.instagram.follow.entity.FollowCompositeKey;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface FollowRepository extends JpaRepository<Follow, Long> {
+    void deleteById(FollowCompositeKey compositeKey);
+}

--- a/src/main/java/com/hanghae/instagram/follow/service/FollowService.java
+++ b/src/main/java/com/hanghae/instagram/follow/service/FollowService.java
@@ -36,16 +36,16 @@ public class FollowService {
             Follow newFollow = new Follow(compositeKey, following, follower);
             followRepository.save(newFollow);
 
-            follower.updateFollower(follower.getFollowerCount() + 1);
-            following.updateFollowing(following.getFollowingCount() + 1);
+            follower.updateFollowerCount(follower.getFollowerCount() + 1);
+            following.updateFollowingCount(following.getFollowingCount() + 1);
 
             return true;
         }
 
         // 언팔로우
         followRepository.deleteById(compositeKey);
-        follower.updateFollower(follower.getFollowerCount() -1);
-        following.updateFollowing(following.getFollowingCount() -1);
+        follower.updateFollowerCount(follower.getFollowerCount() -1);
+        following.updateFollowingCount(following.getFollowingCount() -1);
 
         return false;
     }

--- a/src/main/java/com/hanghae/instagram/follow/service/FollowService.java
+++ b/src/main/java/com/hanghae/instagram/follow/service/FollowService.java
@@ -1,0 +1,55 @@
+package com.hanghae.instagram.follow.service;
+
+import com.hanghae.instagram.follow.dto.RequestFollowDto;
+import com.hanghae.instagram.follow.entity.Follow;
+import com.hanghae.instagram.follow.entity.FollowCompositeKey;
+import com.hanghae.instagram.follow.repository.FollowRepository;
+
+import com.hanghae.instagram.member.entity.Member;
+import com.hanghae.instagram.member.repository.MemberRepository;
+
+import lombok.RequiredArgsConstructor;
+
+import org.hibernate.PropertyValueException;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+
+@Service
+@RequiredArgsConstructor
+public class FollowService {
+
+    private final FollowRepository followRepository;
+    private final MemberRepository memberRepository;
+
+    @Transactional
+    public boolean doFollowAndUnfollow(RequestFollowDto follow) throws PropertyValueException {
+
+        Member following = memberRepository.findByNickname(follow.getFollowing()).orElseThrow();
+        Member follower = memberRepository.findByNickname(follow.getFollower()).orElseThrow();
+
+        FollowCompositeKey compositeKey = new FollowCompositeKey(following.getId(), follower.getId());
+
+        // 팔로우
+        if(!follow.isFollowState()){
+            Follow newFollow = new Follow(compositeKey, following, follower);
+            followRepository.save(newFollow);
+
+            follower.updateFollower(follower.getFollowerCount() + 1);
+            following.updateFollowing(following.getFollowingCount() + 1);
+
+            return true;
+        }
+
+        // 언팔로우
+        followRepository.deleteById(compositeKey);
+        follower.updateFollower(follower.getFollowerCount() -1);
+        following.updateFollowing(following.getFollowingCount() -1);
+
+        return false;
+    }
+
+
+
+}

--- a/src/main/java/com/hanghae/instagram/member/entity/Member.java
+++ b/src/main/java/com/hanghae/instagram/member/entity/Member.java
@@ -50,11 +50,11 @@ public class Member {
 //        this.activated = activated;
     }
 
-    public void updateFollowing(int followingCount){
+    public void updateFollowingCount(int followingCount){
         this.followingCount = followingCount;
     }
 
-    public void updateFollower(int followerCount){
+    public void updateFollowerCount(int followerCount){
         this.followerCount = followerCount;
     }
 

--- a/src/main/java/com/hanghae/instagram/member/entity/Member.java
+++ b/src/main/java/com/hanghae/instagram/member/entity/Member.java
@@ -50,5 +50,12 @@ public class Member {
 //        this.activated = activated;
     }
 
+    public void updateFollowing(int followingCount){
+        this.followingCount = followingCount;
+    }
+
+    public void updateFollower(int followerCount){
+        this.followerCount = followerCount;
+    }
 
 }


### PR DESCRIPTION
## PR 체크사항
PR이 다음 사항을 만족하는지 확인해주세요.

<!-- 
체크하려면 괄호 안에 "x"를 입력하세요. 
각 규칙은 Convention 문서에 있습니다.
PR 제목에 쓰는 prefix는 다음과 같습니다.
🚀 Release
🐛 Fix
✨ Feat
📝 Doc
♻️ Refactor
🔧 Chore
⏪️ Revert
🧪 Test
🎉 Init
-->

- [x] 커밋 제목 규칙
- [x] 커밋 메시지 작성 가이드라인
- [x] 라벨, 담당자, 리뷰어 지정


## PR 타입
어떤 유형의 PR인지 체크해주세요.

<!-- 체크하려면 괄호 안에 "x"를 입력하세요. -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:


## PR 설명
팔로우 기능입니다. 
follow라는 하나의 테이블에서 팔로워, 팔로잉 컬럼으로 나누어 구현하였습니다! 
그 이유는 테이블이 두개로 나뉠경우 말도 안되는 DB에 메모리 낭비가 되기 때문입니다.
저는 그냥 제 기준으로 단순하게 제가 팔로잉한 사람은 팔로잉 테이블에, 나를 팔로워 해준 사람은 필로워 테이블에 저장하고자 하였습니다. 
그러나 기준을 제가 아닌 모두에게 적용해 보았을 때 나를 팔로워 해준 다른 사람의 입장에서는 팔로잉을 한 것이라 두 테이블에 데이터가 저장이 됩니다. 😳... 정말 중요한걸 놓쳤던 것 같습니다!! 

또한 복합키로 설정하였습니다. 그 이유는 언팔로우 및 내가 이 사람을 팔로잉 했는지 등을 조회하는 경우에는 효율적이기 때문입니다!
추가적으로 복합키로 사용할 것이기 때문에 nickname이 아닌 id를 사용하였습니다.  

*헷갈렸던 부분 
저는 계속 
<img width="866" alt="스크린샷 2022-12-28 오전 10 50 23" src="https://user-images.githubusercontent.com/85235063/209744847-0e7f16cc-6083-45c2-a81b-4040aa6e8a94.png">
추가 참고 내용: http://www.gurubee.net/article/84598

사용자 기준 팔로워 리스트 및 팔로잉 리스트를 가져올 때는 복합키로 설정하여도 효율이 없지 않나!? 하고 고민했습니다. 
이 부분에 대해서는 더 공부해봐야할 것 같습니다.

위와 같은 고민으로 현재 제가 할 수 있는 방법 중 가장 효율적이라 판단하여 복합키로 진행하였습니다! 

## 작업사항
- follow entity 설정 및 복합키 설정 
- follow 기능 구현
- 복합키를 통한 삭제 메소드 followRepository에 추가 
- followingCount, followerCount 업로드 메소드 

