### PR TITLE
✨ Feat: 좋아요 카운트 수 스케줄링

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,9 @@ dependencies {
     runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.2'
     runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.2'
 
+    implementation 'net.javacrumbs.shedlock:shedlock-spring:4.14.0'
+    implementation 'net.javacrumbs.shedlock:shedlock-provider-jdbc-template:4.14.0'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/hanghae/instagram/InstagramApplication.java
+++ b/src/main/java/com/hanghae/instagram/InstagramApplication.java
@@ -5,6 +5,9 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
+import net.javacrumbs.shedlock.spring.annotation.EnableSchedulerLock;
+
+@EnableSchedulerLock(defaultLockAtMostFor = "PT30S")
 @EnableScheduling
 @EnableJpaAuditing
 @SpringBootApplication

--- a/src/main/java/com/hanghae/instagram/InstagramApplication.java
+++ b/src/main/java/com/hanghae/instagram/InstagramApplication.java
@@ -1,41 +1,13 @@
 package com.hanghae.instagram;
 
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.hanghae.instagram.member.dto.RequestSignupMemberDto;
-import com.hanghae.instagram.member.entity.Member;
-import com.hanghae.instagram.member.mapper.MemberMapper;
-import com.hanghae.instagram.member.repository.MemberRepository;
-import org.springframework.boot.ApplicationRunner;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.context.annotation.Bean;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
-import javax.annotation.Resource;
-import java.io.InputStream;
-import java.util.List;
-
+@EnableScheduling
 @EnableJpaAuditing
 @SpringBootApplication
 public class InstagramApplication {
-    public static void main(String[] args) {
-        SpringApplication.run(InstagramApplication.class, args);
-    }
-    @Resource
-    private MemberRepository memberRepository;
-    @Resource
-    private MemberMapper memberMapper;
-//    @Bean
-//    public ApplicationRunner applicationRunner() {
-//        return args -> {
-//            InputStream jsonMember = this.getClass().getClassLoader().getResourceAsStream("json/memberData.json");
-//            List<RequestSignupMemberDto> requestSignupMemberDtoList = new ObjectMapper().readValue(jsonMember, new TypeReference<>() {
-//            });
-//            for (int i = 0; i < requestSignupMemberDtoList.size(); i++) {
-//                Member member = memberMapper.toEntity(requestSignupMemberDtoList.get(i));
-//                memberRepository.save(member);
-//            }
-//        };
-//    }
+	public static void main(String[] args) { SpringApplication.run(InstagramApplication.class, args);}
 }

--- a/src/main/java/com/hanghae/instagram/comment/repository/CommentRepository.java
+++ b/src/main/java/com/hanghae/instagram/comment/repository/CommentRepository.java
@@ -1,6 +1,7 @@
 package com.hanghae.instagram.comment.repository;
 
 import com.hanghae.instagram.comment.entity.Comment;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -12,4 +13,8 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
     @Modifying
     @Query("delete from Comment where postingId.id = :postingId")
     void deleteAllByPostingIdInQuery(@Param("postingId") long postingId);
+
+    @Modifying
+    @Query("update Comment c set c.likeCount = :newLikeCount where c.id = :commentId ")
+    void updateLikeCount(Long commentId, int newLikeCount);
 }

--- a/src/main/java/com/hanghae/instagram/like/repository/CommentLikeRepository.java
+++ b/src/main/java/com/hanghae/instagram/like/repository/CommentLikeRepository.java
@@ -1,6 +1,8 @@
 package com.hanghae.instagram.like.repository;
 
 import com.hanghae.instagram.like.entity.CommentLike;
+import com.hanghae.instagram.like.scheduler.LikeDto;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -12,10 +14,14 @@ import java.util.Optional;
 
 public interface CommentLikeRepository extends JpaRepository<CommentLike, Long> {
     Optional<CommentLike> findCommentLikeByNicknameAndCommentId(String nickname, Long commentId);
+
     @Transactional
     @Modifying
     @Query("delete from CommentLike where comment.id = :commentId")
     void deleteAllByCommentIdInQuery(@Param("commentId") long commentId);
 
     List<CommentLike> findAllByCommentId(long commentId);
+
+    @Query("select c.comment.id as id, count(c.comment.id) as likeCount from CommentLike c group by c.comment.id")
+    List<LikeDto> likeCountBatch();
 }

--- a/src/main/java/com/hanghae/instagram/like/repository/PostingLikeRepository.java
+++ b/src/main/java/com/hanghae/instagram/like/repository/PostingLikeRepository.java
@@ -1,12 +1,15 @@
 package com.hanghae.instagram.like.repository;
 
 import com.hanghae.instagram.like.entity.PostingLike;
+import com.hanghae.instagram.like.scheduler.LikeDto;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface PostingLikeRepository extends JpaRepository<PostingLike, Long> {
@@ -15,5 +18,8 @@ public interface PostingLikeRepository extends JpaRepository<PostingLike, Long> 
     @Query("delete from PostingLike where posting.id = :postingId")
     void deleteAllByPostingIdInQuery(@Param("postingId") long postingId);
     Optional<PostingLike> findPostingLikeByNicknameAndPostingId(String nickname, Long postingId);
+
+    @Query("select p.posting.id as id, count(p.posting.id) as likeCount from PostingLike p group by p.posting.id")
+    List<LikeDto> likeCountBatch();
 
 }

--- a/src/main/java/com/hanghae/instagram/like/scheduler/LikeDto.java
+++ b/src/main/java/com/hanghae/instagram/like/scheduler/LikeDto.java
@@ -1,0 +1,7 @@
+package com.hanghae.instagram.like.scheduler;
+
+public interface LikeDto {
+
+	Long getId();
+	Integer getLikeCount();
+}

--- a/src/main/java/com/hanghae/instagram/like/scheduler/LikeScheduler.java
+++ b/src/main/java/com/hanghae/instagram/like/scheduler/LikeScheduler.java
@@ -1,0 +1,38 @@
+package com.hanghae.instagram.like.scheduler;
+
+import java.util.List;
+
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.hanghae.instagram.comment.repository.CommentRepository;
+import com.hanghae.instagram.like.repository.CommentLikeRepository;
+import com.hanghae.instagram.like.repository.PostingLikeRepository;
+import com.hanghae.instagram.posting.repository.PostingRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class LikeScheduler {
+
+	private final PostingLikeRepository postingLikeRepository;
+	private final CommentLikeRepository commentLikeRepository;
+	private final PostingRepository postingRepository;
+	private final CommentRepository commentRepository;
+
+	@Transactional
+	@Scheduled(cron = "0 30 4 L * ?")
+	public void LikeCountSch() {
+
+		List<LikeDto> newPostLikeCountList = postingLikeRepository.likeCountBatch();
+		newPostLikeCountList.stream()
+			.forEach(p -> postingRepository.updateLikeCount(p.getId(), p.getLikeCount()));
+
+		List<LikeDto>  newCommentLikeCountList = commentLikeRepository.likeCountBatch();
+		newCommentLikeCountList.stream()
+			.forEach(c -> commentRepository.updateLikeCount(c.getId(), c.getLikeCount()));
+	}
+
+}

--- a/src/main/java/com/hanghae/instagram/like/scheduler/LikeScheduler.java
+++ b/src/main/java/com/hanghae/instagram/like/scheduler/LikeScheduler.java
@@ -2,9 +2,16 @@ package com.hanghae.instagram.like.scheduler;
 
 import java.util.List;
 
+import javax.sql.DataSource;
+
+import org.springframework.context.annotation.Bean;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
+
+import net.javacrumbs.shedlock.core.LockProvider;
+import net.javacrumbs.shedlock.provider.jdbctemplate.JdbcTemplateLockProvider;
+import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
 
 import com.hanghae.instagram.comment.repository.CommentRepository;
 import com.hanghae.instagram.like.repository.CommentLikeRepository;
@@ -22,7 +29,15 @@ public class LikeScheduler {
 	private final PostingRepository postingRepository;
 	private final CommentRepository commentRepository;
 
+	@Bean
+	public LockProvider lockProvider(DataSource dataSource) {
+		return new JdbcTemplateLockProvider(dataSource);
+	}
+
+	private static final String SEC_30 = "PT30S";
+
 	@Transactional
+	@SchedulerLock(name = "runScenarioOneTime", lockAtMostFor = SEC_30, lockAtLeastFor = SEC_30)
 	@Scheduled(cron = "0 30 4 L * ?")
 	public void LikeCountSch() {
 

--- a/src/main/java/com/hanghae/instagram/posting/repository/PostingRepository.java
+++ b/src/main/java/com/hanghae/instagram/posting/repository/PostingRepository.java
@@ -3,9 +3,15 @@ package com.hanghae.instagram.posting.repository;
 import com.hanghae.instagram.posting.entity.Posting;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 
 public interface PostingRepository extends JpaRepository<Posting, Long> {
     List<Posting> findAllByOrderByModifiedAtDesc(Pageable pageable);
+
+    @Modifying
+    @Query("update Posting p set p.likeCount = :newLikeCount where p.id = :postingId ")
+    void updateLikeCount(Long postingId, int newLikeCount);
 }

--- a/src/main/java/com/hanghae/instagram/sql/ddl.sql
+++ b/src/main/java/com/hanghae/instagram/sql/ddl.sql
@@ -1,0 +1,8 @@
+CREATE TABLE shedlock
+(
+    name       VARCHAR(64),
+    lock_until TIMESTAMP(3) NULL,
+    locked_at  TIMESTAMP(3) NULL,
+    locked_by  VARCHAR(255),
+    PRIMARY KEY (name)
+);


### PR DESCRIPTION
## PR 체크사항
PR이 다음 사항을 만족하는지 확인해주세요.

<!-- 
체크하려면 괄호 안에 "x"를 입력하세요. 
각 규칙은 Convention 문서에 있습니다.
PR 제목에 쓰는 prefix는 다음과 같습니다.
🚀 Release
🐛 Fix
✨ Feat
📝 Doc
♻️ Refactor
🔧 Chore
⏪️ Revert
🧪 Test
🎉 Init
-->

- [x] 커밋 제목 규칙
- [x] 커밋 메시지 작성 가이드라인
- [x] 라벨, 담당자, 리뷰어 지정


## PR 타입
어떤 유형의 PR인지 체크해주세요.

<!-- 체크하려면 괄호 안에 "x"를 입력하세요. -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:


## PR 설명
좋아요 카운트 수 최적화를 위한 고려사항 
1. Lock
2. Native Query
2. Sync Schedule 

#### 1,2 번은 빈번하게 발생하는 좋아요 기능에는 성능저하를 일으킬 것임으로 판단되어, 특정 주기마다 좋아요 개수를 맞추는 방식으로 구현
#### 이 방식이 서비스가 확장될 경우에 1,2번과 같은 경우 보다는 훨씬 유용하다 판단.
#### 또한, 다중 서버일 경우를 고려하여 Lock을 설정하여 스케줄러가 하나의 서버에서만 돌아가도록 설정

<br/>

참고 자료: 
https://tecoble.techcourse.co.kr/post/2022-10-10-like-count/

## 작업사항
- 매 달에 1번 좋아요 카운트 수를 맞추는 스케줄링 구현
- 다중 서버일 경우를 고려하여 스케줄러 Lock 설정 
